### PR TITLE
Fixes for pyproject.toml install issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 43"]
+requires = ["setuptools >= 61"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -42,13 +42,13 @@ include-package-data = true
 #[tool.setuptools.packages]
 #find = {}
 [tool.setuptools.packages.find]
-where = [".",]  # list of folders that contain the packages (["."] by default)
-include = ["archeryutils"]  # package names should match these glob patterns (["*"] by default)
+where = ["."]  # list of folders that contain the packages (["."] by default)
+include = ["archeryutils", "archeryutils.*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["archeryutils.tests*", "examples.py"]  # exclude packages matching these glob patterns (empty by default)
-#namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [tool.setuptools.package-data]
-mypkg = ["* = *.json", "round_data_files/*.json"]
+archeryutils = ["*.json", "round_data_files/*.json", "classifications/*.json"]
 
 #[options.extras_require]
 #tests = pytest


### PR DESCRIPTION
I don't normally use `pyproject.toml`-only builds, so I have no idea what I'm doing.