### PR TITLE
Separate score for round and score for passes into two functions

### DIFF
--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -239,7 +239,7 @@ def agb_indoor_classification_scores(
             hc_scheme,
             hc_params,
             round_score_up=True,
-        )[0]
+        )
         for i, class_i in enumerate(group_data["classes"])
     ]
 
@@ -263,7 +263,7 @@ def agb_indoor_classification_scores(
             hc_scheme,
             hc_params,
             round_score_up=True,
-        )[0]
+        )
         if next_score == score:
             # If already at max score this classification is impossible
             if score == ALL_INDOOR_ROUNDS[roundname].max_score():

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -207,7 +207,7 @@ def agb_old_indoor_classification_scores(
             "AGBold",
             hc_params,
             round_score_up=True,
-        )[0]
+        )
         for i, class_i in enumerate(group_data["classes"])
     ]
 

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -484,7 +484,7 @@ def agb_outdoor_classification_scores(
             "AGB",
             hc_params,
             round_score_up=True,
-        )[0]
+        )
         for i in range(len(group_data["classes"]))
     ]
 

--- a/archeryutils/handicaps/handicap_functions.py
+++ b/archeryutils/handicaps/handicap_functions.py
@@ -88,7 +88,7 @@ def handicap_from_score(
         else:
             handicap = np.ceil(handicap)
 
-        sc_int, _ = hc_eq.score_for_round(
+        sc_int = hc_eq.score_for_round(
             rnd, handicap, hc_sys, hc_dat, arw_d, round_score_up=True
         )
 
@@ -101,7 +101,7 @@ def handicap_from_score(
             hstep = 1.0
         while not min_h_flag:
             handicap += hstep
-            sc_int, _ = hc_eq.score_for_round(
+            sc_int = hc_eq.score_for_round(
                 rnd, handicap, hc_sys, hc_dat, arw_d, round_score_up=True
             )
             if sc_int < score:
@@ -157,13 +157,13 @@ def get_max_score_handicap(
     else:
         round_lim = 1.0
 
-    s_max, _ = hc_eq.score_for_round(
+    s_max = hc_eq.score_for_round(
         rnd, handicap, hc_sys, hc_dat, arw_d, round_score_up=False
     )
     # Work down to where we would round or ceil to max score
     while s_max > max_score - round_lim:
         handicap = handicap + delta_hc
-        s_max, _ = hc_eq.score_for_round(
+        s_max = hc_eq.score_for_round(
             rnd, handicap, hc_sys, hc_dat, arw_d, round_score_up=False
         )
     handicap = handicap - delta_hc  # Undo final iteration that overshoots
@@ -350,7 +350,7 @@ def f_root(
     # Could try and simplify hc_sys and hc_dat in future refactor
     # pylint: disable=too-many-arguments
 
-    val, _ = hc_eq.score_for_round(
+    val = hc_eq.score_for_round(
         round_est, hc_est, sys, hc_data, arw_dia, round_score_up=False
     )
 
@@ -425,7 +425,7 @@ def print_handicap_table(
     )
     table[:, 0] = hcs.copy()
     for i, round_i in enumerate(round_list):
-        table[:, i + 1], _ = hc_eq.score_for_round(
+        table[:, i + 1] = hc_eq.score_for_round(
             round_i,
             hcs,
             hc_sys,

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -498,7 +498,7 @@ class TestScoreForRound:
 
         assert hc_eq.score_for_round(
             test_round, 20.0, hc_system, hc_eq.HcParams(), None, False
-        )[0] == pytest.approx(round_score_expected[0])
+        ) == pytest.approx(round_score_expected[0])
 
     @pytest.mark.parametrize(
         "hc_system,round_score_expected",
@@ -534,7 +534,7 @@ class TestScoreForRound:
         assert (
             hc_eq.score_for_round(
                 test_round, 20.0, hc_system, hc_eq.HcParams(), None, True
-            )[0]
+            )
             == round_score_expected[0]
         )
 

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -367,7 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "score_from_hc, _ = hc_eq.score_for_round(\n",
+    "score_from_hc = hc_eq.score_for_round(\n",
     "    agb_outdoor.york,\n",
     "    38,\n",
     "    \"AGB\",\n",
@@ -392,7 +392,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "score_from_hc, _ = hc_eq.score_for_round(\n",
+    "score_from_hc = hc_eq.score_for_round(\n",
     "    agb_outdoor.york,\n",
     "    38.25,\n",
     "    \"AGB\",\n",
@@ -417,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "score_from_hc, _ = hc_eq.score_for_round(\n",
+    "score_from_hc = hc_eq.score_for_round(\n",
     "    agb_outdoor.york,\n",
     "    38.25,\n",
     "    \"AGB\",\n",
@@ -426,6 +426,31 @@
     ")\n",
     "\n",
     "print(f\"A handicap of 38.25 on a York is a decimal score of {score_from_hc}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee860e8e-a23b-4a06-88a7-04ca209aa092",
+   "metadata": {},
+   "source": [
+    "It is also possible to get the predicted score for each pass in a round using the `score_for_passes` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f743c8-9199-48ea-a0a5-bf309f1a887b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pass_scores = hc_eq.score_for_passes(\n",
+    "    agb_outdoor.york,\n",
+    "    38,\n",
+    "    \"AGB\",\n",
+    "    hcparams,\n",
+    ")\n",
+    "\n",
+    "print(f\"A handicap of 38 on a York gives pass scores of {pass_scores}.\")"
    ]
   },
   {
@@ -726,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #4 

Add `score_for_passes` function that can be called by `score_for_round` such that the latter now returns a single number which is more intuitive.

This is a Breaking Change implemented in preparation for first release.