### PR TITLE
Targetdiameter

### DIFF
--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -1,14 +1,13 @@
 """Constants used in the archeryutils package."""
-from types import SimpleNamespace
 
-TO_METRES = {
+_CONVERSIONS = {
     "metre": 1.0,
     "yard": 0.9144,
     "cm": 0.01,
     "inch": 0.0254,
 }
 
-YARD_ALIASES = {
+_YARD_ALIASES = {
     "Yard",
     "yard",
     "Yards",
@@ -21,7 +20,7 @@ YARD_ALIASES = {
     "yds",
 }
 
-METRE_ALIASES = {
+_METRE_ALIASES = {
     "Metre",
     "metre",
     "Metres",
@@ -32,7 +31,7 @@ METRE_ALIASES = {
     "ms",
 }
 
-CM_ALIASES = {
+_CM_ALIASES = {
     "Centimeter",
     "centimeter",
     "Centimeters",
@@ -43,29 +42,46 @@ CM_ALIASES = {
     "cms",
 }
 
-INCH_ALIASES = {
+_INCH_ALIASES = {
     "Inch",
     "inch",
     "Inches",
     "inches",
 }
 
-
-DistanceUnits = SimpleNamespace(
-    yard = YARD_ALIASES,
-    metre = METRE_ALIASES,
-    cm = CM_ALIASES,
-    inch = INCH_ALIASES,
+_ALIASES = dict(
+    yard = _YARD_ALIASES,
+    metre = _METRE_ALIASES,
+    cm = _CM_ALIASES,
+    inch = _INCH_ALIASES,
 )
 
-def normalise_unit_name(unit: str) -> str | None:
-    """Convert any supported unit name alias into a cannonical string representation"""
-    if unit in YARD_ALIASES:
-        return 'yard'
-    if unit in METRE_ALIASES:
-        return 'metre'
-    if unit in CM_ALIASES:
-        return 'cm'
-    if unit in INCH_ALIASES:
-        return 'inch'
-    return None
+class Length:
+    yard = _YARD_ALIASES
+    metre = _METRE_ALIASES
+    cm = _CM_ALIASES
+    inch = _INCH_ALIASES
+
+    _reversed = {
+        alias: name
+        for name in _CONVERSIONS
+        for alias in _ALIASES[name]
+    }
+
+    _conversions = {
+        alias: factor
+        for name, factor in _CONVERSIONS.items()
+        for alias in _ALIASES[name]
+    }
+
+    @classmethod
+    def to_metres(cls, value: float, unit: str) -> float:
+        return cls._conversions[unit] * value
+
+    @classmethod
+    def from_metres(cls, metre_value: float, unit: str) -> float:
+        return metre_value / cls._conversions[unit]
+
+    @classmethod
+    def definitive_name(cls, alias: str) -> str:
+        return cls._reversed[alias]

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -40,7 +40,8 @@ CM_ALIASES = (
 )
 
 
-class DistanceUnits(SimpleNamespace):
-    yard = YARD_ALIASES
-    metre = METRE_ALIASES
-    cm = CM_ALIASES
+DistanceUnits = SimpleNamespace(
+    yard = YARD_ALIASES,
+    metre = METRE_ALIASES,
+    cm = CM_ALIASES,
+)

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -1,11 +1,14 @@
 """Constants used in the archeryutils package."""
 from types import SimpleNamespace
 
-YARD_TO_METRE = 0.9144
-CM_TO_METRE = 0.01
-INCH_TO_METRE = 0.0254
+TO_METRES = {
+    "metre": 1.0,
+    "yard": 0.9144,
+    "cm": 0.01,
+    "inch": 0.0254,
+}
 
-YARD_ALIASES = (
+YARD_ALIASES = {
     "Yard",
     "yard",
     "Yards",
@@ -16,9 +19,9 @@ YARD_ALIASES = (
     "yd",
     "Yds",
     "yds",
-)
+}
 
-METRE_ALIASES = (
+METRE_ALIASES = {
     "Metre",
     "metre",
     "Metres",
@@ -27,9 +30,9 @@ METRE_ALIASES = (
     "m",
     "Ms",
     "ms",
-)
+}
 
-CM_ALIASES = (
+CM_ALIASES = {
     "Centimeter",
     "centimeter",
     "Centimeters",
@@ -38,14 +41,14 @@ CM_ALIASES = (
     "cm",
     "CMs",
     "cms",
-)
+}
 
-INCH_ALIASES = (
+INCH_ALIASES = {
     "Inch",
     "inch",
     "Inches",
     "inches",
-)
+}
 
 
 DistanceUnits = SimpleNamespace(
@@ -54,3 +57,15 @@ DistanceUnits = SimpleNamespace(
     cm = CM_ALIASES,
     inch = INCH_ALIASES,
 )
+
+def normalise_unit_name(unit: str) -> str | None:
+    """Convert any supported unit name alias into a cannonical string representation"""
+    if unit in YARD_ALIASES:
+        return 'yard'
+    if unit in METRE_ALIASES:
+        return 'metre'
+    if unit in CM_ALIASES:
+        return 'cm'
+    if unit in INCH_ALIASES:
+        return 'inch'
+    return None

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -50,11 +50,12 @@ _INCH_ALIASES = {
 }
 
 _ALIASES = {
-    "yard" : _YARD_ALIASES,
-    "metre" : _METRE_ALIASES,
-    "cm" : _CM_ALIASES,
-    "inch" : _INCH_ALIASES,
+    "yard": _YARD_ALIASES,
+    "metre": _METRE_ALIASES,
+    "cm": _CM_ALIASES,
+    "inch": _INCH_ALIASES,
 }
+
 
 class Length:
     """
@@ -86,11 +87,7 @@ class Length:
     cm = _CM_ALIASES
     inch = _INCH_ALIASES
 
-    _reversed = {
-        alias: name
-        for name in _CONVERSIONS_TO_M
-        for alias in _ALIASES[name]
-    }
+    _reversed = {alias: name for name in _CONVERSIONS_TO_M for alias in _ALIASES[name]}
 
     _conversions = {
         alias: factor

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -49,14 +49,38 @@ _INCH_ALIASES = {
     "inches",
 }
 
-_ALIASES = dict(
-    yard = _YARD_ALIASES,
-    metre = _METRE_ALIASES,
-    cm = _CM_ALIASES,
-    inch = _INCH_ALIASES,
-)
+_ALIASES = {
+    "yard" : _YARD_ALIASES,
+    "metre" : _METRE_ALIASES,
+    "cm" : _CM_ALIASES,
+    "inch" : _INCH_ALIASES,
+}
 
 class Length:
+    """
+    Utility class for Length unit conversions
+
+    Contains common abbreviations, pluralisations and capitilizations for supported
+    units as sets to allow easy membership checks in combination.
+    Methods for conversions to and from metres are provided as classmethods.
+
+    Attributes
+    ----------
+    yard : set[str]
+    metre : set[str]
+    cm: set[str]
+    inch: set[str]
+
+    Methods
+    -------
+    to_metres()
+        Convert distance in any supported unit to metres
+    from_metres()
+        Convert distance in metres to any supported unit
+    definitive_name()
+        Convert any string alias representing a distance unit to a single version.
+    """
+
     yard = _YARD_ALIASES
     metre = _METRE_ALIASES
     cm = _CM_ALIASES
@@ -76,12 +100,15 @@ class Length:
 
     @classmethod
     def to_metres(cls, value: float, unit: str) -> float:
+        """Convert value in metres to given unit"""
         return cls._conversions[unit] * value
 
     @classmethod
     def from_metres(cls, metre_value: float, unit: str) -> float:
+        """Convert value in given unit to metres"""
         return metre_value / cls._conversions[unit]
 
     @classmethod
     def definitive_name(cls, alias: str) -> str:
+        """Convert alias for unit into a single definied name set in constants"""
         return cls._reversed[alias]

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -59,7 +59,7 @@ _ALIASES = {
 
 class Length:
     """
-    Utility class for Length unit conversions
+    Utility class for Length unit conversions.
 
     Contains common abbreviations, pluralisations and capitilizations for supported
     units as sets to allow easy membership checks in combination.
@@ -98,7 +98,7 @@ class Length:
     @classmethod
     def to_metres(cls, value: float, unit: str) -> float:
         """
-        Convert value in metres to given unit
+        Convert value in metres to given unit.
 
         Parameters
         ----------
@@ -122,7 +122,7 @@ class Length:
     @classmethod
     def from_metres(cls, metre_value: float, unit: str) -> float:
         """
-        Convert value in given unit to metres
+        Convert value in given unit to metres.
 
         Parameters
         ----------
@@ -146,7 +146,7 @@ class Length:
     @classmethod
     def definitive_unit(cls, alias: str) -> str:
         """
-        Convert alias for unit into a single definied name set in constants
+        Convert alias for unit into a single definied name set in constants.
 
         Parameters
         ----------

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -97,15 +97,70 @@ class Length:
 
     @classmethod
     def to_metres(cls, value: float, unit: str) -> float:
-        """Convert value in metres to given unit"""
+        """
+        Convert value in metres to given unit
+
+        Parameters
+        ----------
+        value : float
+            scalar value of distance to be converted to metres
+        unit : str
+            units of distance to be converted to metres
+
+        Returns
+        -------
+        float
+            scalar value of converted distance in metres
+
+        Examples
+        --------
+        >>> Length.to_metres(10, "inches")
+        0.254
+        """
         return cls._conversions[unit] * value
 
     @classmethod
     def from_metres(cls, metre_value: float, unit: str) -> float:
-        """Convert value in given unit to metres"""
+        """
+        Convert value in given unit to metres
+
+        Parameters
+        ----------
+        metre_value : float
+            scalar value of distance in metres to be converted
+        unit : str
+            units distance is to be converted TO
+
+        Returns
+        -------
+        float
+            scalar value of converted distance in the provided unit
+
+        Examples
+        --------
+        >>> Length.from_metres(18.3, "yards")
+        20.0131
+        """
         return metre_value / cls._conversions[unit]
 
     @classmethod
-    def definitive_name(cls, alias: str) -> str:
-        """Convert alias for unit into a single definied name set in constants"""
+    def definitive_unit(cls, alias: str) -> str:
+        """
+        Convert alias for unit into a single definied name set in constants
+
+        Parameters
+        ----------
+        alias : str
+            name of unit to be converted
+
+        Returns
+        -------
+        str
+            definitive name of unit
+
+        Examples
+        --------
+        >>> Length.definitive_unit("Metres")
+        "metre"
+        """
         return cls._reversed[alias]

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -1,2 +1,46 @@
 """Constants used in the archeryutils package."""
+from types import SimpleNamespace
+
 YARD_TO_METRE = 0.9144
+CM_TO_METRE = 0.01
+
+YARD_ALIASES = (
+    "Yard",
+    "yard",
+    "Yards",
+    "yards",
+    "Y",
+    "y",
+    "Yd",
+    "yd",
+    "Yds",
+    "yds",
+)
+
+METRE_ALIASES = (
+    "Metre",
+    "metre",
+    "Metres",
+    "metres",
+    "M",
+    "m",
+    "Ms",
+    "ms",
+)
+
+CM_ALIASES = (
+    "Centimeter",
+    "centimeter",
+    "Centimeters",
+    "centimeters",
+    "CM",
+    "cm",
+    "CMs",
+    "cms",
+)
+
+
+class DistanceUnits(SimpleNamespace):
+    yard = YARD_ALIASES
+    metre = METRE_ALIASES
+    cm = CM_ALIASES

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -1,6 +1,6 @@
 """Constants used in the archeryutils package."""
 
-_CONVERSIONS = {
+_CONVERSIONS_TO_M = {
     "metre": 1.0,
     "yard": 0.9144,
     "cm": 0.01,
@@ -88,13 +88,13 @@ class Length:
 
     _reversed = {
         alias: name
-        for name in _CONVERSIONS
+        for name in _CONVERSIONS_TO_M
         for alias in _ALIASES[name]
     }
 
     _conversions = {
         alias: factor
-        for name, factor in _CONVERSIONS.items()
+        for name, factor in _CONVERSIONS_TO_M.items()
         for alias in _ALIASES[name]
     }
 

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -32,10 +32,10 @@ _METRE_ALIASES = {
 }
 
 _CM_ALIASES = {
-    "Centimeter",
-    "centimeter",
-    "Centimeters",
-    "centimeters",
+    "Centimetre",
+    "centimetre",
+    "Centimetres",
+    "centimetres",
     "CM",
     "cm",
     "CMs",

--- a/archeryutils/constants.py
+++ b/archeryutils/constants.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 YARD_TO_METRE = 0.9144
 CM_TO_METRE = 0.01
+INCH_TO_METRE = 0.0254
 
 YARD_ALIASES = (
     "Yard",
@@ -39,9 +40,17 @@ CM_ALIASES = (
     "cms",
 )
 
+INCH_ALIASES = (
+    "Inch",
+    "inch",
+    "Inches",
+    "inches",
+)
+
 
 DistanceUnits = SimpleNamespace(
     yard = YARD_ALIASES,
     metre = METRE_ALIASES,
     cm = CM_ALIASES,
+    inch = INCH_ALIASES,
 )

--- a/archeryutils/handicaps/tests/test_handicap_tables.py
+++ b/archeryutils/handicaps/tests/test_handicap_tables.py
@@ -4,10 +4,9 @@
 # pylint: disable=duplicate-code
 
 from typing import Union
-
 import numpy as np
-import pytest
 from numpy.typing import NDArray
+import pytest
 
 import archeryutils.handicaps.handicap_equations as hc_eq
 import archeryutils.handicaps.handicap_functions as hc_func

--- a/archeryutils/handicaps/tests/test_handicap_tables.py
+++ b/archeryutils/handicaps/tests/test_handicap_tables.py
@@ -4,14 +4,14 @@
 # pylint: disable=duplicate-code
 
 from typing import Union
+
 import numpy as np
-from numpy.typing import NDArray
 import pytest
+from numpy.typing import NDArray
 
 import archeryutils.handicaps.handicap_equations as hc_eq
 import archeryutils.handicaps.handicap_functions as hc_func
-from archeryutils.rounds import Round, Pass
-
+from archeryutils.rounds import Pass, Round
 
 hc_params = hc_eq.HcParams()
 
@@ -19,24 +19,24 @@ hc_params = hc_eq.HcParams()
 york = Round(
     "York",
     [
-        Pass(72, 1.22, "5_zone", 100, "yard", False),
-        Pass(48, 1.22, "5_zone", 80, "yard", False),
-        Pass(24, 1.22, "5_zone", 60, "yard", False),
+        Pass(72, 122, "5_zone", 100, "yard", False),
+        Pass(48, 122, "5_zone", 80, "yard", False),
+        Pass(24, 122, "5_zone", 60, "yard", False),
     ],
 )
 hereford = Round(
     "Hereford",
     [
-        Pass(72, 1.22, "5_zone", 80, "yard", False),
-        Pass(48, 1.22, "5_zone", 60, "yard", False),
-        Pass(24, 1.22, "5_zone", 50, "yard", False),
+        Pass(72, 122, "5_zone", 80, "yard", False),
+        Pass(48, 122, "5_zone", 60, "yard", False),
+        Pass(24, 122, "5_zone", 50, "yard", False),
     ],
 )
 metric122_30 = Round(
     "Metric 122-30",
     [
-        Pass(36, 1.22, "10_zone", 30, "metre", False),
-        Pass(36, 1.22, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 30, "metre", False),
     ],
 )
 

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -3,16 +3,16 @@
 # => disable for handicap tests
 # pylint: disable=duplicate-code
 
-from typing import List, Tuple
-
+from typing import Tuple, List
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
 import archeryutils.handicaps.handicap_equations as hc_eq
 import archeryutils.handicaps.handicap_functions as hc_func
-from archeryutils.rounds import Pass, Round
 from archeryutils.targets import Target
+from archeryutils.rounds import Round, Pass
+
 
 hc_params = hc_eq.HcParams()
 

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -3,16 +3,16 @@
 # => disable for handicap tests
 # pylint: disable=duplicate-code
 
-from typing import Tuple, List
+from typing import List, Tuple
+
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
 import archeryutils.handicaps.handicap_equations as hc_eq
 import archeryutils.handicaps.handicap_functions as hc_func
+from archeryutils.rounds import Pass, Round
 from archeryutils.targets import Target
-from archeryutils.rounds import Round, Pass
-
 
 hc_params = hc_eq.HcParams()
 
@@ -20,62 +20,62 @@ hc_params = hc_eq.HcParams()
 york = Round(
     "York",
     [
-        Pass(72, 1.22, "5_zone", 100, "yard", False),
-        Pass(48, 1.22, "5_zone", 80, "yard", False),
-        Pass(24, 1.22, "5_zone", 60, "yard", False),
+        Pass(72, 122, "5_zone", 100, "yard", False),
+        Pass(48, 122, "5_zone", 80, "yard", False),
+        Pass(24, 122, "5_zone", 60, "yard", False),
     ],
 )
 hereford = Round(
     "Hereford",
     [
-        Pass(72, 1.22, "5_zone", 80, "yard", False),
-        Pass(48, 1.22, "5_zone", 60, "yard", False),
-        Pass(24, 1.22, "5_zone", 50, "yard", False),
+        Pass(72, 122, "5_zone", 80, "yard", False),
+        Pass(48, 122, "5_zone", 60, "yard", False),
+        Pass(24, 122, "5_zone", 50, "yard", False),
     ],
 )
 western = Round(
     "Western",
     [
-        Pass(48, 1.22, "5_zone", 60, "yard", False),
-        Pass(48, 1.22, "5_zone", 50, "yard", False),
+        Pass(48, 122, "5_zone", 60, "yard", False),
+        Pass(48, 122, "5_zone", 50, "yard", False),
     ],
 )
 vegas300 = Round(
     "Vegas 300",
     [
-        Pass(30, 0.4, "10_zone", 20, "yard", True),
+        Pass(30, 40, "10_zone", 20, "yard", True),
     ],
 )
 wa1440_90 = Round(
     "WA1440 90m",
     [
-        Pass(36, 1.22, "10_zone", 90, "metre", False),
-        Pass(36, 1.22, "10_zone", 70, "metre", False),
-        Pass(36, 0.8, "10_zone", 50, "metre", False),
-        Pass(36, 0.8, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 90, "metre", False),
+        Pass(36, 122, "10_zone", 70, "metre", False),
+        Pass(36, 80, "10_zone", 50, "metre", False),
+        Pass(36, 80, "10_zone", 30, "metre", False),
     ],
 )
 wa1440_70 = Round(
     "WA1440 70m",
     [
-        Pass(36, 1.22, "10_zone", 70, "metre", False),
-        Pass(36, 1.22, "10_zone", 60, "metre", False),
-        Pass(36, 0.8, "10_zone", 50, "metre", False),
-        Pass(36, 0.8, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 70, "metre", False),
+        Pass(36, 122, "10_zone", 60, "metre", False),
+        Pass(36, 80, "10_zone", 50, "metre", False),
+        Pass(36, 80, "10_zone", 30, "metre", False),
     ],
 )
 wa720_70 = Round(
     "WA 720 70m",
     [
-        Pass(36, 1.22, "10_zone", 70, "metre", False),
-        Pass(36, 1.22, "10_zone", 70, "metre", False),
+        Pass(36, 122, "10_zone", 70, "metre", False),
+        Pass(36, 122, "10_zone", 70, "metre", False),
     ],
 )
 metric122_30 = Round(
     "Metric 122-30",
     [
-        Pass(36, 1.22, "10_zone", 30, "metre", False),
-        Pass(36, 1.22, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 30, "metre", False),
+        Pass(36, 122, "10_zone", 30, "metre", False),
     ],
 )
 
@@ -387,7 +387,7 @@ class TestArrowScore:
 
         """
         arrow_score = hc_eq.arrow_score(
-            target=Target(0.40, "10_zone_5_ring_compound", 20.0, "metre", indoor),
+            target=Target(40, "10_zone_5_ring_compound", 20.0, "metre", indoor),
             handicap=20.0,
             hc_sys=hc_system,
             hc_dat=hc_params,
@@ -420,7 +420,7 @@ class TestArrowScore:
         Check correct arrow scores returned for different target faces
         """
         arrow_score = hc_eq.arrow_score(
-            target=Target(0.80, target_face, 50.0, "metre", False),
+            target=Target(80, target_face, 50.0, "metre", False),
             handicap=38.0,
             hc_sys="AGB",
             hc_dat=hc_params,
@@ -490,9 +490,9 @@ class TestScoreForRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, 1.22, "10_zone", 100, "metre", False),
-                Pass(10, 0.80, "10_zone", 80, "metre", False),
-                Pass(10, 1.22, "5_zone", 60, "metre", False),
+                Pass(10, 122, "10_zone", 100, "metre", False),
+                Pass(10, 80, "10_zone", 80, "metre", False),
+                Pass(10, 122, "5_zone", 60, "metre", False),
             ],
         )
 
@@ -525,9 +525,9 @@ class TestScoreForRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, 1.22, "10_zone", 100, "metre", False),
-                Pass(10, 0.80, "10_zone", 80, "metre", False),
-                Pass(10, 1.22, "5_zone", 60, "metre", False),
+                Pass(10, 122, "10_zone", 100, "metre", False),
+                Pass(10, 80, "10_zone", 80, "metre", False),
+                Pass(10, 122, "5_zone", 60, "metre", False),
             ],
         )
 
@@ -624,8 +624,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, 1.22, "10_zone", 50, "metre", False),
-                    Pass(10, 0.80, "10_zone", 50, "metre", False),
+                    Pass(10, 122, "10_zone", 50, "metre", False),
+                    Pass(10, 80, "10_zone", 50, "metre", False),
                 ],
             )
 
@@ -645,8 +645,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, 1.22, "10_zone", 50, "metre", False),
-                    Pass(10, 0.80, "10_zone", 50, "metre", False),
+                    Pass(10, 122, "10_zone", 50, "metre", False),
+                    Pass(10, 80, "10_zone", 50, "metre", False),
                 ],
             )
 
@@ -666,8 +666,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, 1.22, "10_zone", 50, "metre", False),
-                    Pass(10, 0.80, "10_zone", 50, "metre", False),
+                    Pass(10, 122, "10_zone", 50, "metre", False),
+                    Pass(10, 80, "10_zone", 50, "metre", False),
                 ],
             )
 

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -1,8 +1,8 @@
 """Module to load round data from json files into DotDicts."""
 import json
-import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Union
+import warnings
+from typing import Union, List, Dict, Any
 
 from archeryutils.rounds import Pass, Round
 

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -1,8 +1,8 @@
 """Module to load round data from json files into DotDicts."""
 import json
-from pathlib import Path
 import warnings
-from typing import Union, List, Dict, Any
+from pathlib import Path
+from typing import Any, Dict, List, Union
 
 from archeryutils.rounds import Pass, Round
 
@@ -107,7 +107,7 @@ def read_json_to_round_dict(json_filelist: Union[str, List[str]]) -> Dict[str, R
             passes = [
                 Pass(
                     pass_i["n_arrows"],
-                    pass_i["diameter"] / 100,
+                    pass_i["diameter"],
                     pass_i["scoring"],
                     pass_i["distance"],
                     dist_unit=pass_i["dist_unit"],

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -166,11 +166,11 @@ class Round:
         """
         max_dist = 0.0
         for pass_i in self.passes:
-            dist = Length.from_metres(pass_i.distance, pass_i.native_dist_unit)
-            if dist > max_dist:
+            if (dist := pass_i.distance) > max_dist:
                 max_dist = dist
                 d_unit = pass_i.native_dist_unit
 
+        max_dist = Length.from_metres(max_dist, d_unit)
         if unit:
             return (max_dist, d_unit)
         return max_dist

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -47,7 +47,9 @@ class Pass:
         diam_unit: str = "cm",
     ) -> None:
         self.n_arrows = abs(n_arrows)
-        self.target = Target(diameter, scoring_system, distance, dist_unit, indoor, diam_unit)
+        self.target = Target(
+            diameter, scoring_system, distance, dist_unit, indoor, diam_unit
+        )
 
     @property
     def distance(self) -> float:
@@ -179,8 +181,12 @@ class Round:
         """Print information about the Round."""
         print(f"A {self.name} consists of {len(self.passes)} passes:")
         for pass_i in self.passes:
-            native_dist = Length.from_metres(pass_i.target.distance, pass_i.native_dist_unit)
-            native_diam = Length.from_metres(pass_i.target.diameter, pass_i.native_diam_unit)
+            native_dist = Length.from_metres(
+                pass_i.target.distance, pass_i.native_dist_unit
+            )
+            native_diam = Length.from_metres(
+                pass_i.target.diameter, pass_i.native_diam_unit
+            )
 
             print(
                 f"\t- {pass_i.n_arrows} arrows "

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,8 +1,8 @@
 """Classes to define a Pass and Round for archery applications."""
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
-from archeryutils.targets import Target
 from archeryutils.constants import YARD_TO_METRE
+from archeryutils.targets import Target
 
 
 class Pass:
@@ -17,7 +17,7 @@ class Pass:
     n_arrows : int
         number of arrows in this pass
     diameter : float
-        face diameter in [metres]
+        face diameter in [centimetres]
     scoring_system : str
         target face/scoring system type
     distance : float

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -168,8 +168,8 @@ class Round:
         """
         max_dist = 0.0
         for pass_i in self.passes:
-            if (dist := pass_i.distance) > max_dist:
-                max_dist = dist
+            if pass_i.distance > max_dist:
+                max_dist = pass_i.distance
                 d_unit = pass_i.native_dist_unit
 
         max_dist = Length.from_metres(max_dist, d_unit)

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -2,7 +2,7 @@
 from typing import List, Union, Tuple
 
 from archeryutils.targets import Target
-from archeryutils.constants import YARD_TO_METRE
+from archeryutils.constants import YARD_TO_METRE, INCH_TO_METRE, CM_TO_METRE
 
 
 class Pass:
@@ -44,9 +44,10 @@ class Pass:
         distance: float,
         dist_unit: str = "metres",
         indoor: bool = False,
+        diam_unit: str = "cm",
     ) -> None:
         self.n_arrows = abs(n_arrows)
-        self.target = Target(diameter, scoring_system, distance, dist_unit, indoor)
+        self.target = Target(diameter, scoring_system, distance, dist_unit, indoor, diam_unit)
 
     @property
     def distance(self) -> float:
@@ -62,6 +63,11 @@ class Pass:
     def diameter(self) -> float:
         """Get diameter."""
         return self.target.diameter
+
+    @property
+    def native_diam_unit(self) -> str:
+        """Get native_diameter unit."""
+        return self.target.native_diameter_unit
 
     @property
     def scoring_system(self) -> str:
@@ -181,8 +187,18 @@ class Round:
                 native_dist = pass_i.target.distance / YARD_TO_METRE
             else:
                 native_dist = pass_i.distance
+
+            # time to generalise unit conversion rather than repeat here and
+            # in target constructor
+            if (diam_unit := pass_i.native_diam_unit) == "inch":
+                native_diam = pass_i.target.diameter / INCH_TO_METRE
+            elif diam_unit == "cm":
+                native_diam = pass_i.target.diameter / CM_TO_METRE
+            else:
+                native_diam = pass_i.target.diameter
+
             print(
                 f"\t- {pass_i.n_arrows} arrows "
-                f"at a {pass_i.diameter * 100.0:.1f} cm target "
+                f"at a {native_diam:.1f} {diam_unit} target "
                 f"at {native_dist:.1f} {pass_i.native_dist_unit}s."
             )

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -2,7 +2,7 @@
 from typing import List, Union, Tuple
 
 from archeryutils.targets import Target
-from archeryutils.constants import YARD_TO_METRE, INCH_TO_METRE, CM_TO_METRE
+from archeryutils.constants import TO_METRES
 
 
 class Pass:
@@ -166,11 +166,7 @@ class Round:
         """
         max_dist = 0.0
         for pass_i in self.passes:
-            dist = (
-                pass_i.distance / YARD_TO_METRE
-                if pass_i.native_dist_unit == "yard"
-                else pass_i.distance
-            )
+            dist = pass_i.distance / TO_METRES[pass_i.native_dist_unit]
             if dist > max_dist:
                 max_dist = dist
                 d_unit = pass_i.native_dist_unit
@@ -183,22 +179,11 @@ class Round:
         """Print information about the Round."""
         print(f"A {self.name} consists of {len(self.passes)} passes:")
         for pass_i in self.passes:
-            if pass_i.native_dist_unit == "yard":
-                native_dist = pass_i.target.distance / YARD_TO_METRE
-            else:
-                native_dist = pass_i.distance
-
-            # time to generalise unit conversion rather than repeat here and
-            # in target constructor
-            if (diam_unit := pass_i.native_diam_unit) == "inch":
-                native_diam = pass_i.target.diameter / INCH_TO_METRE
-            elif diam_unit == "cm":
-                native_diam = pass_i.target.diameter / CM_TO_METRE
-            else:
-                native_diam = pass_i.target.diameter
+            native_dist = pass_i.target.distance / TO_METRES[pass_i.native_dist_unit]
+            native_diam = pass_i.target.diameter / TO_METRES[pass_i.native_diam_unit]
 
             print(
                 f"\t- {pass_i.n_arrows} arrows "
-                f"at a {native_diam:.1f} {diam_unit} target "
+                f"at a {native_diam:.1f} {pass_i.native_diam_unit} target "
                 f"at {native_dist:.1f} {pass_i.native_dist_unit}s."
             )

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,8 +1,8 @@
 """Classes to define a Pass and Round for archery applications."""
-from typing import List, Tuple, Union
+from typing import List, Union, Tuple
 
-from archeryutils.constants import YARD_TO_METRE
 from archeryutils.targets import Target
+from archeryutils.constants import YARD_TO_METRE
 
 
 class Pass:

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -26,11 +26,13 @@ class Pass:
         The unit distance is measured in. default = 'metres'
     indoor : bool
         is round indoors for arrow diameter purposes? default = False
+    diameter_unit : str
+        The unit face diameter is measured in. default = 'centimetres'
 
     Methods
     -------
     max_score()
-        Returns the maximum score for Pass
+      Returns the maximum score for Pass
     """
 
     # Two too many arguments, but logically this structure makes sense => disable
@@ -44,11 +46,11 @@ class Pass:
         distance: float,
         dist_unit: str = "metres",
         indoor: bool = False,
-        diam_unit: str = "cm",
+        diameter_unit: str = "cm",
     ) -> None:
         self.n_arrows = abs(n_arrows)
         self.target = Target(
-            diameter, scoring_system, distance, dist_unit, indoor, diam_unit
+            diameter, scoring_system, distance, dist_unit, indoor, diameter_unit
         )
 
     @property
@@ -67,7 +69,7 @@ class Pass:
         return self.target.diameter
 
     @property
-    def native_diam_unit(self) -> str:
+    def native_diameter_unit(self) -> str:
         """Get native_diameter unit."""
         return self.target.native_diameter_unit
 
@@ -185,11 +187,11 @@ class Round:
                 pass_i.target.distance, pass_i.native_dist_unit
             )
             native_diam = Length.from_metres(
-                pass_i.target.diameter, pass_i.native_diam_unit
+                pass_i.target.diameter, pass_i.native_diameter_unit
             )
 
             print(
                 f"\t- {pass_i.n_arrows} arrows "
-                f"at a {native_diam:.1f} {pass_i.native_diam_unit} target "
+                f"at a {native_diam:.1f} {pass_i.native_diameter_unit} target "
                 f"at {native_dist:.1f} {pass_i.native_dist_unit}s."
             )

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -2,7 +2,7 @@
 from typing import List, Union, Tuple
 
 from archeryutils.targets import Target
-from archeryutils.constants import TO_METRES
+from archeryutils.constants import Length
 
 
 class Pass:
@@ -166,7 +166,7 @@ class Round:
         """
         max_dist = 0.0
         for pass_i in self.passes:
-            dist = pass_i.distance / TO_METRES[pass_i.native_dist_unit]
+            dist = Length.from_metres(pass_i.distance, pass_i.native_dist_unit)
             if dist > max_dist:
                 max_dist = dist
                 d_unit = pass_i.native_dist_unit
@@ -179,8 +179,8 @@ class Round:
         """Print information about the Round."""
         print(f"A {self.name} consists of {len(self.passes)} passes:")
         for pass_i in self.passes:
-            native_dist = pass_i.target.distance / TO_METRES[pass_i.native_dist_unit]
-            native_diam = pass_i.target.diameter / TO_METRES[pass_i.native_diam_unit]
+            native_dist = Length.from_metres(pass_i.target.distance, pass_i.native_dist_unit)
+            native_diam = Length.from_metres(pass_i.target.diameter, pass_i.native_diam_unit)
 
             print(
                 f"\t- {pass_i.n_arrows} arrows "

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -32,7 +32,7 @@ class Pass:
     Methods
     -------
     max_score()
-      Returns the maximum score for Pass
+        Returns the maximum score for Pass
     """
 
     # Two too many arguments, but logically this structure makes sense => disable

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -22,6 +22,7 @@ class Target:
     diamter_unit : str
         Native unit the target size is measured in.
         Converts diameter and stores in [meteres]
+
     Methods
     -------
     max_score()

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -19,7 +19,7 @@ class Target:
         The native unit distance is measured in
     indoor : bool
         is round indoors for arrow diameter purposes? default = False
-    diamter_unit : str
+    native_diameter_unit : str
         Native unit the target size is measured in.
         Converts diameter and stores in [meteres]
 
@@ -41,7 +41,7 @@ class Target:
         distance: float,
         native_dist_unit: str = "metre",
         indoor: bool = False,
-        diameter_unit: str = "cm",
+        native_diameter_unit: str = "cm",
     ) -> None:
         systems = [
             "5_zone",
@@ -75,20 +75,20 @@ class Target:
                 "Select from 'yard' or 'metre'."
             )
 
-        if diameter_unit in DistanceUnits.cm:
-            diameter_unit = "cm"
+        if native_diameter_unit in DistanceUnits.cm:
+            native_diameter_unit = "cm"
             diameter *= CM_TO_METRE
-        elif diameter_unit in DistanceUnits.metre:
-            diameter_unit = "metre"
+        elif native_diameter_unit in DistanceUnits.metre:
+            native_diameter_unit = "metre"
         else:
             raise ValueError(
-                f"Diamter unit '{diameter_unit} not recognised. "
+                f"Diameter unit '{native_diameter_unit}' not recognised. "
                 "Select from 'cm' or 'metre'"
             )
 
         self.native_dist_unit = native_dist_unit
         self.distance = distance
-        self.diameter_unit = diameter_unit
+        self.diameter_unit = native_diameter_unit
         self.diameter = diameter
         self.scoring_system = scoring_system
         self.indoor = indoor

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,6 +1,6 @@
 """Class to represent a Target for archery applications."""
 
-from archeryutils.constants import YARD_TO_METRE
+from archeryutils.constants import CM_TO_METRE, YARD_TO_METRE, DistanceUnits
 
 
 class Target:
@@ -19,7 +19,9 @@ class Target:
         The native unit distance is measured in
     indoor : bool
         is round indoors for arrow diameter purposes? default = False
-
+    diamter_unit : str
+        Native unit the target size is measured in.
+        Converts diameter and stores in [meteres]
     Methods
     -------
     max_score()
@@ -38,6 +40,7 @@ class Target:
         distance: float,
         native_dist_unit: str = "metre",
         indoor: bool = False,
+        diameter_unit: str = "cm",
     ) -> None:
         systems = [
             "5_zone",
@@ -60,29 +63,10 @@ class Target:
                 f"""Please select from '{"', '".join(systems)}'."""
             )
 
-        if native_dist_unit in (
-            "Yard",
-            "yard",
-            "Yards",
-            "yards",
-            "Y",
-            "y",
-            "Yd",
-            "yd",
-            "Yds",
-            "yds",
-        ):
+        if native_dist_unit in DistanceUnits.yard:
             native_dist_unit = "yard"
-        elif native_dist_unit in (
-            "Metre",
-            "metre",
-            "Metres",
-            "metres",
-            "M",
-            "m",
-            "Ms",
-            "ms",
-        ):
+            distance *= YARD_TO_METRE
+        elif native_dist_unit in DistanceUnits.metre:
             native_dist_unit = "metre"
         else:
             raise ValueError(
@@ -90,11 +74,21 @@ class Target:
                 "Select from 'yard' or 'metre'."
             )
 
-        self.diameter = diameter
+        if diameter_unit in DistanceUnits.cm:
+            diameter_unit = "cm"
+            diameter *= CM_TO_METRE
+        elif diameter_unit in DistanceUnits.metre:
+            diameter_unit = "metre"
+        else:
+            raise ValueError(
+                f"Diamter unit '{diameter_unit} not recognised. "
+                "Select from 'cm' or 'metre'"
+            )
+
         self.native_dist_unit = native_dist_unit
-        self.distance = (
-            distance * YARD_TO_METRE if self.native_dist_unit == "yard" else distance
-        )
+        self.distance = distance
+        self.diameter_unit = diameter_unit
+        self.diameter = diameter
         self.scoring_system = scoring_system
         self.indoor = indoor
 

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,6 +1,6 @@
 """Class to represent a Target for archery applications."""
 
-from archeryutils.constants import CM_TO_METRE, YARD_TO_METRE, DistanceUnits
+from archeryutils.constants import CM_TO_METRE, YARD_TO_METRE, INCH_TO_METRE, DistanceUnits
 
 
 class Target:
@@ -78,17 +78,20 @@ class Target:
         if native_diameter_unit in DistanceUnits.cm:
             native_diameter_unit = "cm"
             diameter *= CM_TO_METRE
+        elif native_diameter_unit in DistanceUnits.inch:
+            native_diameter_unit = "inch"
+            diameter *= INCH_TO_METRE
         elif native_diameter_unit in DistanceUnits.metre:
             native_diameter_unit = "metre"
         else:
             raise ValueError(
                 f"Diameter unit '{native_diameter_unit}' not recognised. "
-                "Select from 'cm' or 'metre'"
+                "Select from 'cm', 'inch' or 'metre'"
             )
 
         self.native_dist_unit = native_dist_unit
         self.distance = distance
-        self.diameter_unit = native_diameter_unit
+        self.native_diameter_unit = native_diameter_unit
         self.diameter = diameter
         self.scoring_system = scoring_system
         self.indoor = indoor

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,6 +1,6 @@
 """Class to represent a Target for archery applications."""
 
-from archeryutils.constants import CM_TO_METRE, YARD_TO_METRE, INCH_TO_METRE, DistanceUnits
+from archeryutils.constants import TO_METRES, normalise_unit_name, DistanceUnits
 
 
 class Target:
@@ -63,31 +63,21 @@ class Target:
                 f"""Invalid Target Face Type specified.\n"""
                 f"""Please select from '{"', '".join(systems)}'."""
             )
-
-        if native_dist_unit in DistanceUnits.yard:
-            native_dist_unit = "yard"
-            distance *= YARD_TO_METRE
-        elif native_dist_unit in DistanceUnits.metre:
-            native_dist_unit = "metre"
-        else:
+        if native_dist_unit not in DistanceUnits.yard | DistanceUnits.metre:
             raise ValueError(
                 f"Distance unit '{native_dist_unit}' not recognised. "
                 "Select from 'yard' or 'metre'."
             )
+        native_dist_unit = normalise_unit_name(native_dist_unit)
+        distance *= TO_METRES[native_dist_unit]
 
-        if native_diameter_unit in DistanceUnits.cm:
-            native_diameter_unit = "cm"
-            diameter *= CM_TO_METRE
-        elif native_diameter_unit in DistanceUnits.inch:
-            native_diameter_unit = "inch"
-            diameter *= INCH_TO_METRE
-        elif native_diameter_unit in DistanceUnits.metre:
-            native_diameter_unit = "metre"
-        else:
+        if native_diameter_unit not in DistanceUnits.cm | DistanceUnits.inch | DistanceUnits.metre:
             raise ValueError(
                 f"Diameter unit '{native_diameter_unit}' not recognised. "
                 "Select from 'cm', 'inch' or 'metre'"
             )
+        native_diameter_unit = normalise_unit_name(native_diameter_unit)
+        diameter *= TO_METRES[native_diameter_unit]
 
         self.native_dist_unit = native_dist_unit
         self.distance = distance

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -77,9 +77,9 @@ class Target:
             )
         diameter = Length.to_metres(diameter, native_diameter_unit)
 
-        self.native_dist_unit = Length.definitive_name(native_dist_unit)
+        self.native_dist_unit = Length.definitive_unit(native_dist_unit)
         self.distance = distance
-        self.native_diameter_unit = Length.definitive_name(native_diameter_unit)
+        self.native_diameter_unit = Length.definitive_unit(native_diameter_unit)
         self.diameter = diameter
         self.scoring_system = scoring_system
         self.indoor = indoor

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,6 +1,6 @@
 """Class to represent a Target for archery applications."""
 
-from archeryutils.constants import TO_METRES, normalise_unit_name, DistanceUnits
+from archeryutils.constants import Length
 
 
 class Target:
@@ -63,25 +63,23 @@ class Target:
                 f"""Invalid Target Face Type specified.\n"""
                 f"""Please select from '{"', '".join(systems)}'."""
             )
-        if native_dist_unit not in DistanceUnits.yard | DistanceUnits.metre:
+        if native_dist_unit not in Length.yard | Length.metre:
             raise ValueError(
                 f"Distance unit '{native_dist_unit}' not recognised. "
                 "Select from 'yard' or 'metre'."
             )
-        native_dist_unit = normalise_unit_name(native_dist_unit)
-        distance *= TO_METRES[native_dist_unit]
+        distance = Length.to_metres(distance, native_dist_unit)
 
-        if native_diameter_unit not in DistanceUnits.cm | DistanceUnits.inch | DistanceUnits.metre:
+        if native_diameter_unit not in Length.cm | Length.inch | Length.metre:
             raise ValueError(
                 f"Diameter unit '{native_diameter_unit}' not recognised. "
                 "Select from 'cm', 'inch' or 'metre'"
             )
-        native_diameter_unit = normalise_unit_name(native_diameter_unit)
-        diameter *= TO_METRES[native_diameter_unit]
+        diameter = Length.to_metres(diameter, native_diameter_unit)
 
-        self.native_dist_unit = native_dist_unit
+        self.native_dist_unit = Length.definitive_name(native_dist_unit)
         self.distance = distance
-        self.native_diameter_unit = native_diameter_unit
+        self.native_diameter_unit = Length.definitive_name(native_diameter_unit)
         self.diameter = diameter
         self.scoring_system = scoring_system
         self.indoor = indoor

--- a/archeryutils/tests/test_constants.py
+++ b/archeryutils/tests/test_constants.py
@@ -1,11 +1,14 @@
+"""Tests for constants, including Length class"""
+
 import pytest
 
 from archeryutils.constants import Length
 
-CM = 'cm'
-INCH = 'inch'
-METRE = 'metre'
-YARD = 'yard'
+CM = "cm"
+INCH = "inch"
+METRE = "metre"
+YARD = "yard"
+
 
 class TestLengths:
     """
@@ -23,19 +26,19 @@ class TestLengths:
     def test_pluralised_unit_alises_available(self):
         """Test plurailised versions of common length unit names"""
 
-        assert CM + 's' in Length.cm
-        assert INCH + 'es' in Length.inch
-        assert METRE + 's' in Length.metre
-        assert YARD + 's' in Length.yard
+        assert CM + "s" in Length.cm
+        assert INCH + "es" in Length.inch
+        assert METRE + "s" in Length.metre
+        assert YARD + "s" in Length.yard
 
     @pytest.mark.parametrize(
         "value,unit,result",
         [
-            (10, 'metre', 10),
-            (10, 'cm', 0.1),
-            (10, 'inch', 0.254),
-            (10, 'yard', 9.144),
-        ]
+            (10, "metre", 10),
+            (10, "cm", 0.1),
+            (10, "inch", 0.254),
+            (10, "yard", 9.144),
+        ],
     )
     def test_conversion_to_metres(self, value, unit, result):
         """Test conversion from other units to metres"""
@@ -44,11 +47,11 @@ class TestLengths:
     @pytest.mark.parametrize(
         "value,unit,result",
         [
-            (10, 'metre', 10),
-            (10, 'cm', 1000),
-            (10, 'inch', 393.7008),
-            (10, 'yard', 10.93613),
-        ]
+            (10, "metre", 10),
+            (10, "cm", 1000),
+            (10, "inch", 393.7008),
+            (10, "yard", 10.93613),
+        ],
     )
     def test_conversion_from_metres(self, value, unit, result):
         """Test conversion from metres to other units"""
@@ -57,11 +60,11 @@ class TestLengths:
     @pytest.mark.parametrize(
         "unit,result",
         [
-            ('m', 'metre'),
-            ('centimetre', 'cm'),
-            ('Inch', "inch"),
-            ('yd', "yard"),
-        ]
+            ("m", "metre"),
+            ("centimetre", "cm"),
+            ("Inch", "inch"),
+            ("yd", "yard"),
+        ],
     )
     def test_unit_name_coercion(self, unit, result):
         """Test unit name standardisation available on Length class"""

--- a/archeryutils/tests/test_constants.py
+++ b/archeryutils/tests/test_constants.py
@@ -68,4 +68,4 @@ class TestLengths:
     )
     def test_unit_name_coercion(self, unit, result):
         """Test unit name standardisation available on Length class"""
-        assert Length.definitive_name(unit) == result
+        assert Length.definitive_unit(unit) == result

--- a/archeryutils/tests/test_constants.py
+++ b/archeryutils/tests/test_constants.py
@@ -1,0 +1,68 @@
+import pytest
+
+from archeryutils.constants import Length
+
+CM = 'cm'
+INCH = 'inch'
+METRE = 'metre'
+YARD = 'yard'
+
+class TestLengths:
+    """
+    Tests for Length class
+    """
+
+    def test_units_available(self):
+        """Test common length unit names"""
+
+        assert CM in Length.cm
+        assert INCH in Length.inch
+        assert METRE in Length.metre
+        assert YARD in Length.yard
+
+    def test_pluralised_unit_alises_available(self):
+        """Test plurailised versions of common length unit names"""
+
+        assert CM + 's' in Length.cm
+        assert INCH + 'es' in Length.inch
+        assert METRE + 's' in Length.metre
+        assert YARD + 's' in Length.yard
+
+    @pytest.mark.parametrize(
+        "value,unit,result",
+        [
+            (10, 'metre', 10),
+            (10, 'cm', 0.1),
+            (10, 'inch', 0.254),
+            (10, 'yard', 9.144),
+        ]
+    )
+    def test_conversion_to_metres(self, value, unit, result):
+        """Test conversion from other units to metres"""
+        assert Length.to_metres(value, unit) == result
+
+    @pytest.mark.parametrize(
+        "value,unit,result",
+        [
+            (10, 'metre', 10),
+            (10, 'cm', 1000),
+            (10, 'inch', 393.7008),
+            (10, 'yard', 10.93613),
+        ]
+    )
+    def test_conversion_from_metres(self, value, unit, result):
+        """Test conversion from metres to other units"""
+        assert Length.from_metres(value, unit) == pytest.approx(result)
+
+    @pytest.mark.parametrize(
+        "unit,result",
+        [
+            ('m', 'metre'),
+            ('centimetre', 'cm'),
+            ('Inch', "inch"),
+            ('yd', "yard"),
+        ]
+    )
+    def test_unit_name_coercion(self, unit, result):
+        """Test unit name standardisation available on Length class"""
+        assert Length.definitive_name(unit) == result

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -35,7 +35,9 @@ class TestPass:
         Check that Pass() has same default diameter units as Target.
         """
         test_pass = Pass(36, 122, "5_zone", 50)
-        assert test_pass.native_diam_unit == test_pass.target.native_diameter_unit == "cm"
+        assert (
+            test_pass.native_diam_unit == test_pass.target.native_diameter_unit == "cm"
+        )
 
     def test_diameter_units_passed_to_target(self) -> None:
         """
@@ -176,9 +178,9 @@ class TestRound:
         """
         Check that max distance accounts for different units in round
         """
-        pyards = Pass(36, 122, "5_zone", 80, 'yard')
-        pmetric = Pass(36, 122, "5_zone", 75, 'metres')
-        test_round = Round('test', [pyards, pmetric])
+        pyards = Pass(36, 122, "5_zone", 80, "yard")
+        pmetric = Pass(36, 122, "5_zone", 75, "metres")
+        test_round = Round("test", [pyards, pmetric])
 
         assert pmetric.distance > pyards.distance
         assert test_round.max_distance() == 75

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -172,6 +172,17 @@ class TestRound:
         )
         assert test_round.max_distance() == 100
 
+    def test_max_distance_mixed_units(self) -> None:
+        """
+        Check that max distance accounts for different units in round
+        """
+        pyards = Pass(36, 122, "5_zone", 80, 'yard')
+        pmetric = Pass(36, 122, "5_zone", 75, 'metres')
+        test_round = Round('test', [pyards, pmetric])
+
+        assert pmetric.distance > pyards.distance
+        assert test_round.max_distance() == 75
+
     def test_get_info(self, capsys: pytest.CaptureFixture[str]) -> None:
         """
         Check printing info works as expected.

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -1,6 +1,5 @@
 """Tests for Pass and Round classes"""
-from typing import Tuple, Union
-
+from typing import Union, Tuple
 import pytest
 
 from archeryutils.rounds import Pass, Round

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -36,14 +36,18 @@ class TestPass:
         """
         test_pass = Pass(36, 122, "5_zone", 50)
         assert (
-            test_pass.native_diam_unit == test_pass.target.native_diameter_unit == "cm"
+            test_pass.native_diameter_unit
+            == test_pass.target.native_diameter_unit
+            == "cm"
         )
 
     def test_diameter_units_passed_to_target(self) -> None:
         """
         Check that Pass() passes on diameter units to Target object.
         """
-        test_pass = Pass(60, 16, "Worcester", 20, dist_unit="yards", diam_unit="inches")
+        test_pass = Pass(
+            60, 16, "Worcester", 20, dist_unit="yards", diameter_unit="inches"
+        )
         assert test_pass.target.native_diameter_unit == "inch"
 
     def test_default_location(self) -> None:
@@ -70,7 +74,7 @@ class TestPass:
         assert test_pass.diameter == 1.22
         assert test_pass.scoring_system == "5_zone"
         assert test_pass.indoor is False
-        assert test_pass.native_diam_unit == "cm"
+        assert test_pass.native_diameter_unit == "cm"
 
     @pytest.mark.parametrize(
         "face_type,max_score_expected",

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -1,5 +1,6 @@
 """Tests for Pass and Round classes"""
-from typing import Union, Tuple
+from typing import Tuple, Union
+
 import pytest
 
 from archeryutils.rounds import Pass, Round
@@ -27,28 +28,28 @@ class TestPass:
         """
         Check that Pass() returns distance in metres when units not specified.
         """
-        test_pass = Pass(36, 1.22, "5_zone", 50)
+        test_pass = Pass(36, 122, "5_zone", 50)
         assert test_pass.native_dist_unit == "metre"
 
     def test_default_location(self) -> None:
         """
         Check that Pass() returns indoor=False when indoor not specified.
         """
-        test_pass = Pass(36, 1.22, "5_zone", 50, "metre")
+        test_pass = Pass(36, 122, "5_zone", 50, "metre")
         assert test_pass.indoor is False
 
     def test_negative_arrows(self) -> None:
         """
         Check that Pass() uses abs(narrows).
         """
-        test_pass = Pass(-36, 1.22, "5_zone", 50, "metre")
+        test_pass = Pass(-36, 122, "5_zone", 50, "metre")
         assert test_pass.n_arrows == 36
 
     def test_properties(self) -> None:
         """
         Check that Pass properties are set correctly
         """
-        test_pass = Pass(36, 1.22, "5_zone", 50, "metre", False)
+        test_pass = Pass(36, 122, "5_zone", 50, "metre", False)
         assert test_pass.distance == 50.0
         assert test_pass.native_dist_unit == "metre"
         assert test_pass.diameter == 1.22
@@ -74,7 +75,7 @@ class TestPass:
         """
         Check that Pass.max_score() method is functioning correctly
         """
-        test_pass = Pass(100, 1.22, face_type, 50, "metre", False)
+        test_pass = Pass(100, 122, face_type, 50, "metre", False)
         assert test_pass.max_score() == max_score_expected
 
 
@@ -102,9 +103,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(100, 1.22, "5_zone", 50, "metre", False),
-                Pass(100, 1.22, "5_zone", 40, "metre", False),
-                Pass(100, 1.22, "5_zone", 30, "metre", False),
+                Pass(100, 122, "5_zone", 50, "metre", False),
+                Pass(100, 122, "5_zone", 40, "metre", False),
+                Pass(100, 122, "5_zone", 30, "metre", False),
             ],
         )
         assert test_round.max_score() == 2700
@@ -135,9 +136,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, 1.22, "5_zone", 100, unit, False),
-                Pass(10, 1.22, "5_zone", 80, unit, False),
-                Pass(10, 1.22, "5_zone", 60, unit, False),
+                Pass(10, 122, "5_zone", 100, unit, False),
+                Pass(10, 122, "5_zone", 80, unit, False),
+                Pass(10, 122, "5_zone", 60, unit, False),
             ],
         )
         assert test_round.max_distance(unit=get_unit) == max_dist_expected
@@ -150,9 +151,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, 1.22, "5_zone", 80, "metre", False),
-                Pass(10, 1.22, "5_zone", 100, "metre", False),
-                Pass(10, 1.22, "5_zone", 60, "metre", False),
+                Pass(10, 122, "5_zone", 80, "metre", False),
+                Pass(10, 122, "5_zone", 100, "metre", False),
+                Pass(10, 122, "5_zone", 60, "metre", False),
             ],
         )
         assert test_round.max_distance() == 100
@@ -164,9 +165,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, 1.22, "5_zone", 100, "metre", False),
-                Pass(20, 1.22, "5_zone", 80, "yards", False),
-                Pass(30, 0.80, "5_zone", 60, "metre", False),
+                Pass(10, 122, "5_zone", 100, "metre", False),
+                Pass(20, 122, "5_zone", 80, "yards", False),
+                Pass(30, 80, "5_zone", 60, "metre", False),
             ],
         )
         test_round.get_info()

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -30,6 +30,20 @@ class TestPass:
         test_pass = Pass(36, 122, "5_zone", 50)
         assert test_pass.native_dist_unit == "metre"
 
+    def test_default_diameter_unit(self) -> None:
+        """
+        Check that Pass() has same default diameter units as Target.
+        """
+        test_pass = Pass(36, 122, "5_zone", 50)
+        assert test_pass.native_diam_unit == test_pass.target.native_diameter_unit == "cm"
+
+    def test_diameter_units_passed_to_target(self) -> None:
+        """
+        Check that Pass() passes on diameter units to Target object.
+        """
+        test_pass = Pass(60, 16, "Worcester", 20, dist_unit="yards", diam_unit="inches")
+        assert test_pass.target.native_diameter_unit == "inch"
+
     def test_default_location(self) -> None:
         """
         Check that Pass() returns indoor=False when indoor not specified.
@@ -48,12 +62,13 @@ class TestPass:
         """
         Check that Pass properties are set correctly
         """
-        test_pass = Pass(36, 122, "5_zone", 50, "metre", False)
+        test_pass = Pass(36, 122, "5_zone", 50, "metre", False, "cm")
         assert test_pass.distance == 50.0
         assert test_pass.native_dist_unit == "metre"
         assert test_pass.diameter == 1.22
         assert test_pass.scoring_system == "5_zone"
         assert test_pass.indoor is False
+        assert test_pass.native_diam_unit == "cm"
 
     @pytest.mark.parametrize(
         "face_type,max_score_expected",

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -24,7 +24,7 @@ class TestTarget:
             ValueError,
             match="Invalid Target Face Type specified.\nPlease select from '(.+)'.",
         ):
-            Target(1.22, "InvalidScoringSystem", 50, "m", False)
+            Target(122, "InvalidScoringSystem", 50, "m", False)
 
     def test_invalid_distance_unit(self) -> None:
         """
@@ -34,28 +34,43 @@ class TestTarget:
             ValueError,
             match="Distance unit '(.+)' not recognised. Select from 'yard' or 'metre'.",
         ):
-            Target(1.22, "5_zone", 50, "InvalidDistanceUnit", False)
+            Target(122, "5_zone", 50, "InvalidDistanceUnit", False)
 
     def test_default_distance_unit(self) -> None:
         """
         Check that Target() returns distance in metres when units not specified.
         """
-        target = Target(1.22, "5_zone", 50)
+        target = Target(122, "5_zone", 50)
         assert target.native_dist_unit == "metre"
-
-    def test_default_location(self) -> None:
-        """
-        Check that Target() returns indoor=False when indoor not specified.
-        """
-        target = Target(1.22, "5_zone", 50, "m")
-        assert target.indoor is False
 
     def test_yard_to_m_conversion(self) -> None:
         """
         Check that Target() returns correct distance in metres when yards provided.
         """
-        target = Target(1.22, "5_zone", 50, "yards")
+        target = Target(122, "5_zone", 50, "yards")
         assert target.distance == 50.0 * 0.9144
+
+    def test_invalid_diameter_unit(self) -> None:
+        with pytest.raises(ValueError):
+            Target(122, "5_zone", 50, "yards", diameter_unit="InvalidDiamterUnit")
+
+    @pytest.mark.xfail(
+        reason="Only implemented cm conversions in #27",
+        raises=ValueError,
+    )
+    def test_unsupported_diameter_unit(self) -> None:
+        Target(16, "Worcester", 20, "yards", indoor=True, diameter_unit="inches")
+
+    def test_default_diameter_unit_and_conversion(self) -> None:
+        target = Target(80, "10_zone_5_ring_compound", 50, "metres", diameter_unit="cm")
+        assert target.diameter == 80 * 0.01
+
+    def test_default_location(self) -> None:
+        """
+        Check that Target() returns indoor=False when indoor not specified.
+        """
+        target = Target(122, "5_zone", 50, "m")
+        assert target.indoor is False
 
     @pytest.mark.parametrize(
         "face_type,max_score_expected",
@@ -78,7 +93,7 @@ class TestTarget:
         """
         Check that Target() returns correct max score.
         """
-        target = Target(1.22, face_type, 50, "metre", False)
+        target = Target(122, face_type, 50, "metre", False)
         assert target.max_score() == max_score_expected
 
     def test_max_score_invalid_face_type(self) -> None:
@@ -89,7 +104,7 @@ class TestTarget:
             ValueError,
             match="Target face '(.+)' has no specified maximum score.",
         ):
-            target = Target(1.22, "5_zone", 50, "metre", False)
+            target = Target(122, "5_zone", 50, "metre", False)
             # Requires manual resetting of scoring system to get this error.
             target.scoring_system = "InvalidScoringSystem"
             target.max_score()
@@ -115,7 +130,7 @@ class TestTarget:
         """
         Check that Target() returns correct min score.
         """
-        target = Target(1.22, face_type, 50, "metre", False)
+        target = Target(122, face_type, 50, "metre", False)
         assert target.min_score() == min_score_expected
 
     def test_min_score_invalid_face_type(self) -> None:
@@ -126,7 +141,7 @@ class TestTarget:
             ValueError,
             match="Target face '(.+)' has no specified minimum score.",
         ):
-            target = Target(1.22, "5_zone", 50, "metre", False)
+            target = Target(122, "5_zone", 50, "metre", False)
             # Requires manual resetting of scoring system to get this error.
             target.scoring_system = "InvalidScoringSystem"
             target.min_score()

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -51,19 +51,28 @@ class TestTarget:
         assert target.distance == 50.0 * 0.9144
 
     def test_invalid_diameter_unit(self) -> None:
-        with pytest.raises(ValueError):
-            Target(122, "5_zone", 50, "yards", diameter_unit="InvalidDiamterUnit")
+        """
+        Check that Target() raises an error when called with invalid/unsupported diameter units.
+        """
+        with pytest.raises(
+            ValueError,
+            match="Diameter unit '(.+)' not recognised. Select from 'cm' or 'metre'",
+        ):
+            Target(122, "5_zone", 50, "yards", native_diameter_unit="InvalidDiamterUnit")
 
-    @pytest.mark.xfail(
-        reason="Only implemented cm conversions in #27",
-        raises=ValueError,
-    )
-    def test_unsupported_diameter_unit(self) -> None:
-        Target(16, "Worcester", 20, "yards", indoor=True, diameter_unit="inches")
-
-    def test_default_diameter_unit_and_conversion(self) -> None:
-        target = Target(80, "10_zone_5_ring_compound", 50, "metres", diameter_unit="cm")
+    def test_default_diameter_unit(self) -> None:
+        """
+        Check that Target() is using centimetres by default for diameter.
+        """
+        target = Target(80, "10_zone_5_ring_compound", 50, "metres")
         assert target.diameter == 80 * 0.01
+
+    def test_diameter_metres_not_converted(self) -> None:
+        """
+        Check that Target() is storing diameter in metres
+        """
+        target = Target(0.04, "Beiter_hit_miss", 18, native_diameter_unit="m")
+        assert target.diameter == 0.04
 
     def test_default_location(self) -> None:
         """

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -50,15 +50,15 @@ class TestTarget:
         target = Target(122, "5_zone", 50, "yards")
         assert target.distance == 50.0 * 0.9144
 
-    def test_invalid_diameter_unit(self) -> None:
+    def test_unsupported_diameter_unit(self) -> None:
         """
-        Check that Target() raises an error when called with invalid/unsupported diameter units.
+        Check that Target() raises an error when called with unsupported diameter units.
         """
         with pytest.raises(
             ValueError,
-            match="Diameter unit '(.+)' not recognised. Select from 'cm' or 'metre'",
+            match="Diameter unit '(.+)' not recognised. Select from 'cm', 'inch' or 'metre'",
         ):
-            Target(122, "5_zone", 50, "yards", native_diameter_unit="InvalidDiamterUnit")
+            Target(122, "5_zone", 50, "yards", native_diameter_unit="feet")
 
     def test_default_diameter_unit(self) -> None:
         """
@@ -69,10 +69,17 @@ class TestTarget:
 
     def test_diameter_metres_not_converted(self) -> None:
         """
-        Check that Target() is storing diameter in metres
+        Check that Target() is storing diameter in metres.
         """
         target = Target(0.04, "Beiter_hit_miss", 18, native_diameter_unit="m")
         assert target.diameter == 0.04
+
+    def test_diameter_inches_supported(self) -> None:
+        """
+        Check that Target() converts diameters in inches correctly.
+        """
+        target = Target(16, "Worcester", 20, "yards", indoor=True, native_diameter_unit="inches")
+        assert target.diameter == 16 * 0.0254
 
     def test_default_location(self) -> None:
         """

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -78,7 +78,9 @@ class TestTarget:
         """
         Check that Target() converts diameters in inches correctly.
         """
-        target = Target(16, "Worcester", 20, "yards", indoor=True, native_diameter_unit="inches")
+        target = Target(
+            16, "Worcester", 20, "yards", indoor=True, native_diameter_unit="inches"
+        )
         assert target.diameter == 16 * 0.0254
 
     def test_diameter_distance_units_coerced_to_definitive_names(self) -> None:
@@ -86,8 +88,16 @@ class TestTarget:
         Check that Target coerces aliased distance units into standard names
         """
 
-        imperial_target = Target(16, "Worcester", 20, "Yards", indoor=True, native_diameter_unit="Inches")
-        metric_target = Target(80, "10_zone", 30, native_dist_unit="Metres", native_diameter_unit="Centimetres")
+        imperial_target = Target(
+            16, "Worcester", 20, "Yards", indoor=True, native_diameter_unit="Inches"
+        )
+        metric_target = Target(
+            80,
+            "10_zone",
+            30,
+            native_dist_unit="Metres",
+            native_diameter_unit="Centimetres",
+        )
 
         assert imperial_target.native_dist_unit == "yard"
         assert imperial_target.native_diameter_unit == "inch"

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -81,6 +81,19 @@ class TestTarget:
         target = Target(16, "Worcester", 20, "yards", indoor=True, native_diameter_unit="inches")
         assert target.diameter == 16 * 0.0254
 
+    def test_diameter_distance_units_coerced_to_definitive_names(self) -> None:
+        """
+        Check that Target coerces aliased distance units into standard names
+        """
+
+        imperial_target = Target(16, "Worcester", 20, "Yards", indoor=True, native_diameter_unit="Inches")
+        metric_target = Target(80, "10_zone", 30, native_dist_unit="Metres", native_diameter_unit="Centimetres")
+
+        assert imperial_target.native_dist_unit == "yard"
+        assert imperial_target.native_diameter_unit == "inch"
+        assert metric_target.native_dist_unit == "metre"
+        assert metric_target.native_diameter_unit == "cm"
+
     def test_default_location(self) -> None:
         """
         Check that Target() returns indoor=False when indoor not specified.

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -39,7 +39,7 @@
     "### Target\n",
     "\n",
     "A target is defined with the following attributes:\n",
-    "- Face diameter [m]\n",
+    "- Face diameter [default cm]\n",
     "- Scoring system\n",
     "- Distance [default m]\n",
     "\n",
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my720target = au.targets.Target(1.22, \"10_zone\", 70.0)"
+    "my720target = au.targets.Target(122, \"10_zone\", 70.0)"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mycompound720target = au.targets.Target(0.80, \"10_zone_6_ring\", 50.0)"
+    "mycompound720target = au.targets.Target(80, \"10_zone_6_ring\", 50.0)"
    ]
   },
   {
@@ -97,6 +97,7 @@
    "source": [
     "The target object can also take the optional arguments of:\n",
     "- `native_dist_unit` - string - default = `\"metres\"`\n",
+    "- `native_diameter_unit` - string - default = `\"cm\"`\n",
     "- `indoor` - boolean - default = `False`\n",
     "\n",
     "to provide an imperial distance in yards and indicate if the round is to be shot indoors (where rules may be different).\n",
@@ -129,8 +130,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "myPortsmouthTarget = au.targets.Target(\n",
-    "    0.60, \"10_zone\", 20.0, native_dist_unit=\"yards\", indoor=True\n",
+    "myWorcesterTarget = au.targets.Target(\n",
+    "    16,\n",
+    "    \"Worcester\",\n",
+    "    20.0,\n",
+    "    native_dist_unit=\"yards\",\n",
+    "    native_diameter_unit=\"inches\",\n",
+    "    indoor=True,\n",
     ")"
    ]
   },
@@ -149,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for target in [my720target, mycompound720target, myIFAATarget, myPortsmouthTarget]:\n",
+    "for target in [my720target, mycompound720target, myIFAATarget, myWorcesterTarget]:\n",
     "    print(target.max_score())"
    ]
   },
@@ -174,7 +180,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my70mPass = au.rounds.Pass(36, 1.22, \"10_zone\", 70.0)"
+    "my70mPass = au.rounds.Pass(36, 122, \"10_zone\", 70.0)"
    ]
   },
   {
@@ -751,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,3 @@ archeryutils = ["*.json", "round_data_files/*.json", "classifications/*.json"]
 [tool.mypy]
 warn_unused_configs = true
 plugins = ["numpy.typing.mypy_plugin"]
-
-[tool.pytest]
-xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ lint = [
     "coverage",
     "pytest>=7.2.0",
     "pytest-mock",
+    "pydocstyle",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ archeryutils = ["*.json", "round_data_files/*.json", "classifications/*.json"]
 [tool.mypy]
 warn_unused_configs = true
 plugins = ["numpy.typing.mypy_plugin"]
+
+[tool.pytest]
+xfail_strict = true


### PR DESCRIPTION
Closes #27 
Set default target diameter units to cm
Updates tests and load_rounds functionality
Round data files all seem to specify target face sizes in cm already so enforcing this as the default unit makes sense.

Aliases for distance units moved into the constants file as it was getting out of hand and avoiding repitition, choice of conversion constants handled in the branching points in `Target.__init__`, this could perhaps be handled more elegantly if more units need to be supported in the future but didn't want to change more than necessary for now.