### PR TITLE
Add Target, Pass, and Round to top level namespace.

### DIFF
--- a/archeryutils/__init__.py
+++ b/archeryutils/__init__.py
@@ -1,8 +1,12 @@
 """Package providing code for various archery utilities."""
 
-from archeryutils import load_rounds, rounds, targets
+from archeryutils import rounds, targets
 from archeryutils.handicaps import handicap_equations, handicap_functions
 from archeryutils import classifications
+
+from archeryutils.targets import Target
+from archeryutils.rounds import Pass, Round
+
 
 __all__ = [
     "rounds",
@@ -10,4 +14,7 @@ __all__ = [
     "handicap_equations",
     "handicap_functions",
     "classifications",
+    "Target",
+    "Pass",
+    "Round",
 ]

--- a/archeryutils/__init__.py
+++ b/archeryutils/__init__.py
@@ -1,20 +1,16 @@
 """Package providing code for various archery utilities."""
 
-from archeryutils import rounds, targets
+from archeryutils.targets import Target
+from archeryutils.rounds import Pass, Round
 from archeryutils.handicaps import handicap_equations, handicap_functions
 from archeryutils import classifications
 
-from archeryutils.targets import Target
-from archeryutils.rounds import Pass, Round
-
 
 __all__ = [
-    "rounds",
-    "targets",
-    "handicap_equations",
-    "handicap_functions",
-    "classifications",
     "Target",
     "Pass",
     "Round",
+    "handicap_equations",
+    "handicap_functions",
+    "classifications",
 ]

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "source": [
     "## 1. Basic Building Blocks\n",
-    "The basic building blocks of the archeryutils package are the `targets.Target` and the `rounds.Round` class.\n",
+    "The basic building blocks of the archeryutils package are the `Target` and the `Round` classes.\n",
     "\n",
     "### Target\n",
     "\n",
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my720target = au.targets.Target(\"10_zone\", 122, 70.0)"
+    "my720target = au.Target(\"10_zone\", 122, 70.0)"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mycompound720target = au.targets.Target(\"10_zone_6_ring\", 80, 50.0)"
+    "mycompound720target = au.Target(\"10_zone_6_ring\", 80, 50.0)"
    ]
   },
   {
@@ -111,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "myWorcesterTarget = au.targets.Target(\n",
+    "myWorcesterTarget = au.Target(\n",
     "    \"Worcester\", diameter=(16, \"inches\"), distance=(20.0, \"yards\"), indoor=True\n",
     ")"
    ]
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "myIFAATarget = au.targets.Target(\"IFAA_field\", diameter=80, distance=(80.0, \"yards\"))"
+    "myIFAATarget = au.Target(\"IFAA_field\", diameter=80, distance=(80.0, \"yards\"))"
    ]
   },
   {
@@ -174,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my70mPass = au.rounds.Pass(36, \"10_zone\", 122, 70.0)"
+    "my70mPass = au.Pass(36, \"10_zone\", 122, 70.0)"
    ]
   },
   {
@@ -222,7 +222,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my720Round = au.rounds.Round(\n",
+    "my720Round = au.Round(\n",
     "    \"WA 720 (70m)\",\n",
     "    [my70mPass, my70mPass],\n",
     "    location=\"Outdoor Target\",\n",


### PR DESCRIPTION
Closes #3 

As proposed by @LiamPattinson it would simplify things if a few choice items are added to the top level namespace of _archeryutils_.

This PR adds the `Target`, `Pass`, and `Round` classes to `archeryutils/__init__.py`.

I think keeping handicaps and classifications as explicit imports is sensible as users either want these or not, and they are somewhat distinct.