### PR TITLE
Add versioning function for debugging

### DIFF
--- a/archeryutils/__init__.py
+++ b/archeryutils/__init__.py
@@ -4,6 +4,7 @@ from archeryutils.targets import Target
 from archeryutils.rounds import Pass, Round
 from archeryutils.handicaps import handicap_equations, handicap_functions
 from archeryutils import classifications
+from archeryutils.utils import versions
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "handicap_equations",
     "handicap_functions",
     "classifications",
+    "versions",
 ]

--- a/archeryutils/utils.py
+++ b/archeryutils/utils.py
@@ -1,0 +1,106 @@
+"""Utility functions for printing version information."""
+
+# This is not integral to the functioning of archeryutils and serves debugging purposes.
+# For this reason it is excluded from tests and coverage checks with `  # pragma: no cover`.
+
+import importlib
+import locale
+import os
+import platform
+import struct
+import subprocess
+import sys
+from typing import Union
+
+
+def _get_sys_info() -> list:  # pragma: no cover
+    """Return system information as a dict."""
+    blob: list = []
+
+    # get full commit hash
+    commit = None
+    if os.path.isdir(".git") and os.path.isdir("archeryutils"):
+        with subprocess.Popen(
+            'git log --format="%H" -n 1'.split(" "),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as pipe:
+            commit_raw, _ = pipe.communicate()
+        commit = commit_raw.decode("utf-8").strip().strip('"')
+
+    blob.append(("commit", commit))
+
+    (sysname, _, release, _, machine, processor) = platform.uname()
+    blob.extend(
+        [
+            ("python", sys.version),
+            ("python-bits", struct.calcsize("P") * 8),
+            ("OS", f"{sysname}"),
+            ("OS-release", f"{release}"),
+            ("machine", f"{machine}"),
+            ("processor", f"{processor}"),
+            ("byteorder", f"{sys.byteorder}"),
+            ("LC_ALL", f'{os.environ.get("LC_ALL", "None")}'),
+            ("LANG", f'{os.environ.get("LANG", "None")}'),
+            ("LOCALE", f"{locale.getlocale()}"),
+        ]
+    )
+
+    return blob
+
+
+def versions() -> None:  # pragma: no cover
+    """Print the versions of archeryutils and its dependencies to screen."""
+    sys_info = _get_sys_info()
+
+    deps = [
+        # (MODULE_NAME, f(mod) -> mod version)
+        ("archeryutils", lambda mod: mod.__version__),
+        ("numpy", lambda mod: mod.__version__),
+        # optionals
+        # setup/lint/test
+        ("setuptools", lambda mod: mod.__version__),
+        ("pip", lambda mod: mod.__version__),
+        ("black", lambda mod: mod.__version__),
+        ("pylint", lambda mod: mod.__version__),
+        ("coverage", lambda mod: mod.__version__),
+        ("pydocstyle", lambda mod: mod.__version__),
+        ("pytest", lambda mod: mod.__version__),
+        ("pytest_mock", lambda mod: importlib.metadata.version(mod.__name__)),
+        ("mypy", lambda mod: importlib.metadata.version(mod.__name__)),
+        # docs
+        ("sphinx", lambda mod: mod.__version__),
+        ("sphinx_rtd_theme", lambda mod: mod.__version__),
+        ("sphinx_toolbox", lambda mod: mod.__version__),
+        ("nbsphinx", lambda mod: mod.__version__),
+        ("IPython", lambda mod: mod.__version__),
+    ]
+
+    deps_blob: list[tuple[str, Union[str, None]]] = []
+    for modname, ver_f in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+        except ModuleNotFoundError:
+            deps_blob.append((modname, None))
+        else:
+            try:
+                ver = ver_f(mod)
+                deps_blob.append((modname, ver))
+            except AttributeError:
+                deps_blob.append((modname, "installed"))
+
+    print("\nSYSTEM INFORMATION")
+    print("------------------")
+
+    for k, stat in sys_info:
+        print(f"{k}: {stat}")
+
+    print("")
+    print("\nINSTALLED VERSIONS")
+    print("------------------")
+
+    for k, stat in deps_blob:
+        print(f"{k}: {stat}")


### PR DESCRIPTION
Add utils file with debugging function for printing system and module information.

Can be used via:
```python
import archeryutils as au

au.versions()
```

Prints system info and installed version of modules for users to add to bug reports.