### PR TITLE
Simplify HcParams interface

### DIFF
--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -268,7 +268,6 @@ def agb_indoor_classification_scores(
     group_data = agb_indoor_classifications[groupname]
 
     hc_scheme = "AGB"
-    hc_params = hc_eq.HcParams()
 
     # Get scores required on this round for each classification
     # Enforce full size face
@@ -277,7 +276,6 @@ def agb_indoor_classification_scores(
             ALL_INDOOR_ROUNDS[cls_funcs.strip_spots(roundname)],
             group_data["class_HC"][i],
             hc_scheme,
-            hc_params,
             round_score_up=True,
         )
         for i, class_i in enumerate(group_data["classes"])
@@ -301,7 +299,6 @@ def agb_indoor_classification_scores(
             ALL_INDOOR_ROUNDS[cls_funcs.strip_spots(roundname)],
             np.floor(handicap) + 1,
             hc_scheme,
-            hc_params,
             round_score_up=True,
         )
         if next_score == score:

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -233,15 +233,12 @@ def agb_old_indoor_classification_scores(
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_old_indoor_classifications[groupname]
 
-    hc_params = hc_eq.HcParams()
-
     # Get scores required on this round for each classification
     class_scores = [
         hc_eq.score_for_round(
             ALL_INDOOR_ROUNDS[roundname],
             group_data["class_HC"][i],
             "AGBold",
-            hc_params,
             round_score_up=True,
         )
         for i, class_i in enumerate(group_data["classes"])

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -520,15 +520,12 @@ def agb_outdoor_classification_scores(
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_outdoor_classifications[groupname]
 
-    hc_params = hc_eq.HcParams()
-
     # Get scores required on this round for each classification
     class_scores = [
         hc_eq.score_for_round(
             ALL_OUTDOOR_ROUNDS[cls_funcs.strip_spots(roundname)],
             group_data["class_HC"][i],
             "AGB",
-            hc_params,
             round_score_up=True,
         )
         for i in range(len(group_data["classes"]))

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -15,8 +15,6 @@ from archeryutils.targets import Target
 from archeryutils.rounds import Round, Pass
 
 
-hc_params = hc_eq.HcParams()
-
 # Define rounds used in these functions
 york = Round(
     "York",
@@ -175,7 +173,6 @@ class TestSigmaT:
                 handicap=10.0,
                 hc_sys="InvalidSystem",
                 dist=10.0,
-                hc_dat=hc_params,
             )
 
     @pytest.mark.parametrize(
@@ -210,7 +207,6 @@ class TestSigmaT:
             handicap=handicap,
             hc_sys=system,
             dist=distance,
-            hc_dat=hc_params,
         )
 
         assert theta == pytest.approx(theta_expected)
@@ -225,7 +221,6 @@ class TestSigmaT:
             handicap=handicap_array,
             hc_sys="AGB",
             dist=100.0,
-            hc_dat=hc_params,
         )
 
         np.testing.assert_allclose(theta_array, theta_expected_array)
@@ -264,7 +259,6 @@ class TestSigmaR:
                 handicap=10.0,
                 hc_sys="InvalisHandicapSystem",
                 dist=10.0,
-                hc_dat=hc_params,
             )
 
     @pytest.mark.parametrize(
@@ -299,7 +293,6 @@ class TestSigmaR:
             handicap=handicap,
             hc_sys=system,
             dist=distance,
-            hc_dat=hc_params,
         )
 
         assert sigma_r == pytest.approx(sigma_r_expected)
@@ -314,7 +307,6 @@ class TestSigmaR:
             handicap=handicap_array,
             hc_sys="AGB",
             dist=100.0,
-            hc_dat=hc_params,
         )
 
         np.testing.assert_allclose(sigma_r_array, sigma_r_expected_array)
@@ -355,7 +347,6 @@ class TestArrowScore:
                 target=target,
                 handicap=12.0,
                 hc_sys="AGB",
-                hc_dat=hc_params,
                 arw_d=None,
             )
 
@@ -391,7 +382,6 @@ class TestArrowScore:
             target=Target("10_zone_5_ring_compound", 40, 20.0, indoor),
             handicap=20.0,
             hc_sys=hc_system,
-            hc_dat=hc_params,
             arw_d=arrow_diameter,
         )
 
@@ -424,7 +414,6 @@ class TestArrowScore:
             target=Target(target_face, 80, 50.0, False),
             handicap=38.0,
             hc_sys="AGB",
-            hc_dat=hc_params,
             arw_d=None,
         )
 
@@ -498,7 +487,7 @@ class TestScoreForRound:
         )
 
         assert hc_eq.score_for_round(
-            test_round, 20.0, hc_system, hc_eq.HcParams(), None, False
+            test_round, 20.0, hc_system, round_score_up=False
         ) == pytest.approx(round_score_expected[0])
 
     @pytest.mark.parametrize(
@@ -533,9 +522,7 @@ class TestScoreForRound:
         )
 
         assert (
-            hc_eq.score_for_round(
-                test_round, 20.0, hc_system, hc_eq.HcParams(), None, True
-            )
+            hc_eq.score_for_round(test_round, 20.0, hc_system, round_score_up=True)
             == round_score_expected[0]
         )
 
@@ -604,9 +591,7 @@ class TestHandicapFromScore:
         handicap = hc_func.get_max_score_handicap(
             testround,
             hc_system,
-            hc_params,
-            None,
-            int_prec,
+            int_prec=int_prec,
         )
 
         assert pytest.approx(handicap) == handicap_expected
@@ -630,7 +615,7 @@ class TestHandicapFromScore:
                 ],
             )
 
-            hc_func.handicap_from_score(9999, test_round, "AGB", hc_params)
+            hc_func.handicap_from_score(9999, test_round, "AGB")
 
     def test_score_of_zero(self) -> None:
         """
@@ -651,7 +636,7 @@ class TestHandicapFromScore:
                 ],
             )
 
-            hc_func.handicap_from_score(0, test_round, "AGB", hc_params)
+            hc_func.handicap_from_score(0, test_round, "AGB")
 
     def test_score_below_zero(self) -> None:
         """
@@ -672,7 +657,7 @@ class TestHandicapFromScore:
                 ],
             )
 
-            hc_func.handicap_from_score(-9999, test_round, "AGB", hc_params)
+            hc_func.handicap_from_score(-9999, test_round, "AGB")
 
     @pytest.mark.parametrize(
         "hc_system,testround,max_score,handicap_expected",
@@ -704,9 +689,7 @@ class TestHandicapFromScore:
             max_score,
             testround,
             hc_system,
-            hc_params,
-            None,
-            True,
+            int_prec=True,
         )
 
         assert handicap == handicap_expected
@@ -768,9 +751,7 @@ class TestHandicapFromScore:
             testscore,
             testround,
             hc_system,
-            hc_params,
-            None,
-            True,
+            int_prec=True,
         )
 
         assert handicap == handicap_expected
@@ -810,9 +791,7 @@ class TestHandicapFromScore:
             testscore,
             testround,
             hc_system,
-            hc_params,
-            None,
-            False,
+            int_prec=False,
         )
 
         assert handicap == pytest.approx(handicap_expected)

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -150,8 +150,6 @@ Archery GB (Atkinson (2023), Lane (1978)) and Archery Australia (Park (2014)).
     from archeryutils import handicap_equations as hc_eq
     from archeryutils import handicap_functions as hc_func
 
-    hcparams = hc_eq.HcParams()
-
 Given a handicap and a round we can calculate the score that would be achieved:
 
 .. ipython:: python
@@ -160,7 +158,6 @@ Given a handicap and a round we can calculate the score that would be achieved:
         agb_outdoor.york,
         38,
         "AGB",
-        hcparams,
     )
 
     print(f"A handicap of 38 on a York is a score of {score_from_hc}.")
@@ -169,7 +166,6 @@ Given a handicap and a round we can calculate the score that would be achieved:
         agb_outdoor.york,
         38,
         "AGB",
-        hcparams,
     )
 
     print(f"A handicap of 38 on a York gives pass scores of {pass_scores}.")
@@ -183,7 +179,6 @@ to a handicap:
         950,
         agb_outdoor.york,
         "AGB",
-        hcparams,
     )
     print(f"A score of 950 on a York is a continuous handicap of {hc_from_score}.")
 
@@ -191,7 +186,6 @@ to a handicap:
         950,
         agb_outdoor.york,
         "AGB",
-        hcparams,
         int_prec=True,
     )
     print(f"A score of 950 on a York is a discrete handicap of {hc_from_score}.")
@@ -214,7 +208,6 @@ There are also inbuilt methods for generating handicap tables:
         handicaps,
         "AGB",
         rounds,
-        hcparams,
     )
 
 Classifications

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -320,10 +320,7 @@
     "## 2. Handicap Schemes\n",
     "_archeryutils_ provides functionality for calculating various [handicaps/skill ratings](https://jackatkinson.net/post/archery_handicap/) from scores. These include both the popular Archery GB and Archery Australia schemes.\n",
     "\n",
-    "To use these functionalities import the handicap equations and functions modules as below.\n",
-    "\n",
-    "It will also help to instantiate a `HcParams` object that contains key parameters for the handicap schemes.\n",
-    "This comes as a preloaded dataclass, though the values of the variables can be changed or loaded from a `.json` file. For an explanation of the different values consult the [class definition in `archeryutils/handicaps/handicap_equations.py`](https://github.com/jatkinson1000/archeryutils/blob/main/archeryutils/handicaps/handicap_equations.py)."
+    "To use these functionalities import the handicap equations and functions modules as below."
    ]
   },
   {
@@ -334,10 +331,7 @@
    "outputs": [],
    "source": [
     "from archeryutils import handicap_equations as hc_eq\n",
-    "from archeryutils import handicap_functions as hc_func\n",
-    "\n",
-    "hcparams = hc_eq.HcParams()\n",
-    "print(hcparams)"
+    "from archeryutils import handicap_functions as hc_func"
    ]
   },
   {
@@ -371,7 +365,6 @@
     "    agb_outdoor.york,\n",
     "    38,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     ")\n",
     "\n",
     "print(f\"A handicap of 38 on a York is a score of {score_from_hc}.\")"
@@ -396,7 +389,6 @@
     "    agb_outdoor.york,\n",
     "    38.25,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     ")\n",
     "\n",
     "print(f\"A handicap of 38.25 on a York is a score of {score_from_hc}.\")"
@@ -421,7 +413,6 @@
     "    agb_outdoor.york,\n",
     "    38.25,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     "    round_score_up=False,\n",
     ")\n",
     "\n",
@@ -447,7 +438,6 @@
     "    agb_outdoor.york,\n",
     "    38,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     ")\n",
     "\n",
     "print(f\"A handicap of 38 on a York gives pass scores of {pass_scores}.\")"
@@ -481,7 +471,6 @@
     "    950,\n",
     "    agb_outdoor.york,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     ")\n",
     "print(f\"A score of 950 on a York is a continuous handicap of {hc_from_score}.\")\n",
     "\n",
@@ -489,7 +478,6 @@
     "    950,\n",
     "    agb_outdoor.york,\n",
     "    \"AGB\",\n",
-    "    hcparams,\n",
     "    int_prec=True,\n",
     ")\n",
     "print(f\"A score of 950 on a York is a discrete handicap of {hc_from_score}.\")"
@@ -528,7 +516,6 @@
     "    handicaps,\n",
     "    \"AGB\",\n",
     "    rounds,\n",
-    "    hcparams,\n",
     ")"
    ]
   },
@@ -562,7 +549,6 @@
     "    handicaps,\n",
     "    \"AGB\",\n",
     "    rounds,\n",
-    "    hcparams,\n",
     "    round_scores_up=False,\n",
     "    clean_gaps=False,\n",
     "    filename=\"test_handicap_table.txt\",\n",


### PR DESCRIPTION
Closes #2 

As discussed, `HcParams` is made an optional parameter and we fall back on default values if not otherwise specified.
Needs docstring for `HcParams` making clear what the various contents are.

- [x] Source code updated to address issue
- [x] Style and formatting applied
- [x] Tests written to cover changes
- [ ] Docstrings included/updated in code
- [ ] Project documentation updated as necessary