### PR TITLE
Typing Improvements

### DIFF
--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -13,7 +13,6 @@ agb_field_classification_scores
 
 import re
 from typing import TypedDict
-import numpy as np
 
 from archeryutils import load_rounds
 import archeryutils.classifications.classification_utils as cls_funcs
@@ -259,11 +258,6 @@ def agb_field_classification_scores(
     # Get scores required on this round for each classification
     class_scores = group_data["class_scores"]
 
-    # Make sure that hc.eq.score_for_round did not return array to satisfy mypy
-    if any(isinstance(x, np.ndarray) for x in class_scores):
-        raise TypeError(
-            "score_for_round is attempting to return an array when float expected."
-        )
     # Score threshold should be int (score_for_round called with round=True)
     # Enforce this for better code and to satisfy mypy
     int_class_scores = [int(x) for x in class_scores]

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -63,134 +63,43 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
         "3rd Class",
     ]
 
+    agb_field_scores = {
+        ("Compound", "Male", "Adult") : [393, 377, 344, 312, 279, 247],
+        ("Compound", "Female", "Adult") : [376, 361, 330, 299, 268, 237],
+        ("Recurve", "Male", "Adult") : [338, 317, 288, 260, 231, 203],
+        ("Recurve", "Female", "Adult") : [322, 302, 275, 247, 220, 193],
+        ("Barebow", "Male", "Adult"): [328, 307, 279, 252, 224, 197],
+        ("Barebow", "Female", "Adult"): [303, 284, 258, 233, 207, 182],
+        ("Longbow", "Male", "Adult"): [201, 188, 171, 155, 137, 121],
+        ("Longbow", "Female", "Adult"): [303, 284, 258, 233, 207, 182],
+        ("Traditional", "Male", "Adult"): [262, 245, 223, 202, 178, 157],
+        ("Traditional", "Female", "Adult"): [197, 184, 167, 152, 134, 118],
+        ("Flatbow", "Male", "Adult"): [262, 245, 223, 202, 178, 157],
+        ("Flatbow", "Female", "Adult"): [197, 184, 167, 152, 134, 118],
+        ("Compound", "Male", "Under 18") : [385, 369, 337, 306, 273, 242],
+        ("Compound", "Female", "Under 18") : [357, 343, 314, 284, 255, 225],
+        ("Recurve", "Male", "Under 18") : [311, 292, 265, 239, 213, 187],
+        ("Recurve", "Female", "Under 18") : [280, 263, 239, 215, 191, 168],
+        ("Barebow", "Male", "Under 18") : [298, 279, 254, 229, 204, 179],
+        ("Barebow", "Female", "Under 18") : [251, 236, 214, 193, 172, 151],
+        ("Longbow", "Male", "Under 18") : [161, 150, 137, 124, 109, 96],
+        ("Longbow", "Female", "Under 18") : [122, 114, 103, 94, 83, 73],
+        ("Traditional", "Male", "Under 18") : [210, 196, 178, 161, 143, 126],
+        ("Traditional", "Female", "Under 18") : [158, 147, 134, 121, 107, 95],
+        ("Flatbow", "Male", "Under 18") : [210, 196, 178, 161, 143, 126],
+        ("Flatbow", "Female", "Under 18") : [158, 147, 134, 121, 107, 95],
+    }
+
     # Generate dict of classifications
-    # for both bowstyles, for both genders
-    compound_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [393, 377, 344, 312, 279, 247],
-    }
-    compound_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [376, 361, 330, 299, 268, 237],
-    }
-    recurve_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [338, 317, 288, 260, 231, 203],
-    }
-    recurve_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [322, 302, 275, 247, 220, 193],
-    }
-    barebow_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [328, 307, 279, 252, 224, 197],
-    }
-    barebow_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [303, 284, 258, 233, 207, 182],
-    }
-    longbow_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [201, 188, 171, 155, 137, 121],
-    }
-    longbow_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [303, 284, 258, 233, 207, 182],
-    }
-    traditional_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [262, 245, 223, 202, 178, 157],
-    }
-    traditional_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [197, 184, 167, 152, 134, 118],
-    }
-    flatbow_male_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [262, 245, 223, 202, 178, 157],
-    }
-    flatbow_female_adult: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [197, 184, 167, 152, 134, 118],
-    }
+    classification_dict = {}
 
-    # Juniors
-    compound_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [385, 369, 337, 306, 273, 242],
-    }
-    compound_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [357, 343, 314, 284, 255, 225],
-    }
-    recurve_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [311, 292, 265, 239, 213, 187],
-    }
-    recurve_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [280, 263, 239, 215, 191, 168],
-    }
-    barebow_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [298, 279, 254, 229, 204, 179],
-    }
-    barebow_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [251, 236, 214, 193, 172, 151],
-    }
-    longbow_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [161, 150, 137, 124, 109, 96],
-    }
-    longbow_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [122, 114, 103, 94, 83, 73],
-    }
-    traditional_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [210, 196, 178, 161, 143, 126],
-    }
-    traditional_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [158, 147, 134, 121, 107, 95],
-    }
-    flatbow_male_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [210, 196, 178, 161, 143, 126],
-    }
-    flatbow_female_u18: GroupData = {
-        "classes": agb_field_classes,
-        "class_scores": [158, 147, 134, 121, 107, 95],
-    }
-
-    get_groupname = cls_funcs.get_groupname
-    classification_dict = {
-        get_groupname("Compound", "Male", "Adult") : compound_male_adult,
-        get_groupname("Compound", "Female", "Adult") : compound_female_adult,
-        get_groupname("Recurve", "Male", "Adult") : recurve_male_adult,
-        get_groupname("Recurve", "Female", "Adult") : recurve_female_adult,
-        get_groupname("Barebow", "Male", "Adult"): barebow_male_adult,
-        get_groupname("Barebow", "Female", "Adult"): barebow_female_adult,
-        get_groupname("Longbow", "Male", "Adult"): longbow_male_adult,
-        get_groupname("Longbow", "Female", "Adult"): longbow_female_adult,
-        get_groupname("Traditional", "Male", "Adult"): traditional_male_adult,
-        get_groupname("Traditional", "Female", "Adult"): traditional_female_adult,
-        get_groupname("Flatbow", "Male", "Adult"): flatbow_male_adult,
-        get_groupname("Flatbow", "Female", "Adult"): flatbow_female_adult,
-        get_groupname("Compound", "Male", "Under 18") : compound_male_u18,
-        get_groupname("Compound", "Female", "Under 18") : compound_female_u18,
-        get_groupname("Recurve", "Male", "Under 18") : recurve_male_u18,
-        get_groupname("Recurve", "Female", "Under 18") : recurve_female_u18,
-        get_groupname("Barebow", "Male", "Under 18") : barebow_male_u18,
-        get_groupname("Barebow", "Female", "Under 18") : barebow_female_u18,
-        get_groupname("Longbow", "Male", "Under 18") : longbow_male_u18,
-        get_groupname("Longbow", "Female", "Under 18") : longbow_female_u18,
-        get_groupname("Traditional", "Male", "Under 18") : traditional_male_u18,
-        get_groupname("Traditional", "Female", "Under 18") : traditional_female_u18,
-        get_groupname("Flatbow", "Male", "Under 18") : flatbow_male_u18,
-        get_groupname("Flatbow", "Female", "Under 18") : flatbow_female_u18,
-    }
+    for group, scores in agb_field_scores.items():
+        groupdata: GroupData = {
+            "classes": agb_field_classes,
+            "class_scores": scores
+        }
+        groupname = cls_funcs.get_groupname(*group)
+        classification_dict[groupname] = groupdata
 
     return classification_dict
 

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -12,7 +12,7 @@ agb_field_classification_scores
 # pylint: disable=duplicate-code
 
 import re
-from typing import Any, TypedDict
+from typing import TypedDict
 import numpy as np
 
 from archeryutils import load_rounds
@@ -189,7 +189,7 @@ def calculate_agb_field_classification(
         return "unclassified"
 
     # What is the highest classification this score gets?
-    class_scores: dict[str, Any] = dict(
+    class_scores = dict(
         zip(group_data["classes"], group_data["class_scores"])
     )
     for item in class_scores:

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -27,6 +27,8 @@ ALL_AGBFIELD_ROUNDS = load_rounds.read_json_to_round_dict(
 
 
 class GroupData(TypedDict):
+    """Structure for AGB Field classification data."""
+
     classes: list[str]
     class_scores: list[int]
 
@@ -64,10 +66,10 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
     ]
 
     agb_field_scores = {
-        ("Compound", "Male", "Adult") : [393, 377, 344, 312, 279, 247],
-        ("Compound", "Female", "Adult") : [376, 361, 330, 299, 268, 237],
-        ("Recurve", "Male", "Adult") : [338, 317, 288, 260, 231, 203],
-        ("Recurve", "Female", "Adult") : [322, 302, 275, 247, 220, 193],
+        ("Compound", "Male", "Adult"): [393, 377, 344, 312, 279, 247],
+        ("Compound", "Female", "Adult"): [376, 361, 330, 299, 268, 237],
+        ("Recurve", "Male", "Adult"): [338, 317, 288, 260, 231, 203],
+        ("Recurve", "Female", "Adult"): [322, 302, 275, 247, 220, 193],
         ("Barebow", "Male", "Adult"): [328, 307, 279, 252, 224, 197],
         ("Barebow", "Female", "Adult"): [303, 284, 258, 233, 207, 182],
         ("Longbow", "Male", "Adult"): [201, 188, 171, 155, 137, 121],
@@ -76,28 +78,25 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
         ("Traditional", "Female", "Adult"): [197, 184, 167, 152, 134, 118],
         ("Flatbow", "Male", "Adult"): [262, 245, 223, 202, 178, 157],
         ("Flatbow", "Female", "Adult"): [197, 184, 167, 152, 134, 118],
-        ("Compound", "Male", "Under 18") : [385, 369, 337, 306, 273, 242],
-        ("Compound", "Female", "Under 18") : [357, 343, 314, 284, 255, 225],
-        ("Recurve", "Male", "Under 18") : [311, 292, 265, 239, 213, 187],
-        ("Recurve", "Female", "Under 18") : [280, 263, 239, 215, 191, 168],
-        ("Barebow", "Male", "Under 18") : [298, 279, 254, 229, 204, 179],
-        ("Barebow", "Female", "Under 18") : [251, 236, 214, 193, 172, 151],
-        ("Longbow", "Male", "Under 18") : [161, 150, 137, 124, 109, 96],
-        ("Longbow", "Female", "Under 18") : [122, 114, 103, 94, 83, 73],
-        ("Traditional", "Male", "Under 18") : [210, 196, 178, 161, 143, 126],
-        ("Traditional", "Female", "Under 18") : [158, 147, 134, 121, 107, 95],
-        ("Flatbow", "Male", "Under 18") : [210, 196, 178, 161, 143, 126],
-        ("Flatbow", "Female", "Under 18") : [158, 147, 134, 121, 107, 95],
+        ("Compound", "Male", "Under 18"): [385, 369, 337, 306, 273, 242],
+        ("Compound", "Female", "Under 18"): [357, 343, 314, 284, 255, 225],
+        ("Recurve", "Male", "Under 18"): [311, 292, 265, 239, 213, 187],
+        ("Recurve", "Female", "Under 18"): [280, 263, 239, 215, 191, 168],
+        ("Barebow", "Male", "Under 18"): [298, 279, 254, 229, 204, 179],
+        ("Barebow", "Female", "Under 18"): [251, 236, 214, 193, 172, 151],
+        ("Longbow", "Male", "Under 18"): [161, 150, 137, 124, 109, 96],
+        ("Longbow", "Female", "Under 18"): [122, 114, 103, 94, 83, 73],
+        ("Traditional", "Male", "Under 18"): [210, 196, 178, 161, 143, 126],
+        ("Traditional", "Female", "Under 18"): [158, 147, 134, 121, 107, 95],
+        ("Flatbow", "Male", "Under 18"): [210, 196, 178, 161, 143, 126],
+        ("Flatbow", "Female", "Under 18"): [158, 147, 134, 121, 107, 95],
     }
 
     # Generate dict of classifications
     classification_dict = {}
 
     for group, scores in agb_field_scores.items():
-        groupdata: GroupData = {
-            "classes": agb_field_classes,
-            "class_scores": scores
-        }
+        groupdata: GroupData = {"classes": agb_field_classes, "class_scores": scores}
         groupname = cls_funcs.get_groupname(*group)
         classification_dict[groupname] = groupdata
 

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -12,7 +12,7 @@ agb_field_classification_scores
 # pylint: disable=duplicate-code
 
 import re
-from typing import Any
+from typing import Any, TypedDict
 import numpy as np
 
 from archeryutils import load_rounds
@@ -26,7 +26,12 @@ ALL_AGBFIELD_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_field_classification_dict() -> dict[str, dict[str, Any]]:
+class GroupData(TypedDict):
+    classes: list[str]
+    class_scores: list[int]
+
+
+def _make_agb_field_classification_dict() -> dict[str, GroupData]:
     """
     Generate AGB outdoor classification data.
 
@@ -60,117 +65,131 @@ def _make_agb_field_classification_dict() -> dict[str, dict[str, Any]]:
 
     # Generate dict of classifications
     # for both bowstyles, for both genders
-    classification_dict = {}
-    classification_dict[cls_funcs.get_groupname("Compound", "Male", "Adult")] = {
+    compound_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [393, 377, 344, 312, 279, 247],
     }
-    classification_dict[cls_funcs.get_groupname("Compound", "Female", "Adult")] = {
+    compound_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [376, 361, 330, 299, 268, 237],
     }
-    classification_dict[cls_funcs.get_groupname("Recurve", "Male", "Adult")] = {
+    recurve_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [338, 317, 288, 260, 231, 203],
     }
-    classification_dict[cls_funcs.get_groupname("Recurve", "Female", "Adult")] = {
+    recurve_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [322, 302, 275, 247, 220, 193],
     }
-    classification_dict[cls_funcs.get_groupname("Barebow", "Male", "Adult")] = {
+    barebow_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [328, 307, 279, 252, 224, 197],
     }
-    classification_dict[cls_funcs.get_groupname("Barebow", "Female", "Adult")] = {
+    barebow_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [303, 284, 258, 233, 207, 182],
     }
-    classification_dict[cls_funcs.get_groupname("Longbow", "Male", "Adult")] = {
+    longbow_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [201, 188, 171, 155, 137, 121],
     }
-    classification_dict[cls_funcs.get_groupname("Longbow", "Female", "Adult")] = {
+    longbow_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [303, 284, 258, 233, 207, 182],
     }
-    classification_dict[cls_funcs.get_groupname("Traditional", "Male", "Adult")] = {
+    traditional_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [262, 245, 223, 202, 178, 157],
     }
-    classification_dict[cls_funcs.get_groupname("Traditional", "Female", "Adult")] = {
+    traditional_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [197, 184, 167, 152, 134, 118],
     }
-    classification_dict[cls_funcs.get_groupname("Flatbow", "Male", "Adult")] = {
+    flatbow_male_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [262, 245, 223, 202, 178, 157],
     }
-    classification_dict[cls_funcs.get_groupname("Flatbow", "Female", "Adult")] = {
+    flatbow_female_adult: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [197, 184, 167, 152, 134, 118],
     }
 
     # Juniors
-    classification_dict[cls_funcs.get_groupname("Compound", "Male", "Under 18")] = {
+    compound_male_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [385, 369, 337, 306, 273, 242],
     }
-
-    classification_dict[cls_funcs.get_groupname("Compound", "Female", "Under 18")] = {
+    compound_female_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [357, 343, 314, 284, 255, 225],
     }
-
-    classification_dict[cls_funcs.get_groupname("Recurve", "Male", "Under 18")] = {
+    recurve_male_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [311, 292, 265, 239, 213, 187],
     }
-
-    classification_dict[cls_funcs.get_groupname("Recurve", "Female", "Under 18")] = {
+    recurve_female_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [280, 263, 239, 215, 191, 168],
     }
-
-    classification_dict[cls_funcs.get_groupname("Barebow", "Male", "Under 18")] = {
+    barebow_male_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [298, 279, 254, 229, 204, 179],
     }
-
-    classification_dict[cls_funcs.get_groupname("Barebow", "Female", "Under 18")] = {
+    barebow_female_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [251, 236, 214, 193, 172, 151],
     }
-
-    classification_dict[cls_funcs.get_groupname("Longbow", "Male", "Under 18")] = {
+    longbow_male_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [161, 150, 137, 124, 109, 96],
     }
-
-    classification_dict[cls_funcs.get_groupname("Longbow", "Female", "Under 18")] = {
+    longbow_female_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [122, 114, 103, 94, 83, 73],
     }
-
-    classification_dict[cls_funcs.get_groupname("Traditional", "Male", "Under 18")] = {
+    traditional_male_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [210, 196, 178, 161, 143, 126],
     }
-
-    classification_dict[
-        cls_funcs.get_groupname("Traditional", "Female", "Under 18")
-    ] = {
+    traditional_female_u18: GroupData = {
+        "classes": agb_field_classes,
+        "class_scores": [158, 147, 134, 121, 107, 95],
+    }
+    flatbow_male_u18: GroupData = {
+        "classes": agb_field_classes,
+        "class_scores": [210, 196, 178, 161, 143, 126],
+    }
+    flatbow_female_u18: GroupData = {
         "classes": agb_field_classes,
         "class_scores": [158, 147, 134, 121, 107, 95],
     }
 
-    classification_dict[cls_funcs.get_groupname("Flatbow", "Male", "Under 18")] = {
-        "classes": agb_field_classes,
-        "class_scores": [210, 196, 178, 161, 143, 126],
-    }
-
-    classification_dict[cls_funcs.get_groupname("Flatbow", "Female", "Under 18")] = {
-        "classes": agb_field_classes,
-        "class_scores": [158, 147, 134, 121, 107, 95],
+    get_groupname = cls_funcs.get_groupname
+    classification_dict = {
+        get_groupname("Compound", "Male", "Adult") : compound_male_adult,
+        get_groupname("Compound", "Female", "Adult") : compound_female_adult,
+        get_groupname("Recurve", "Male", "Adult") : recurve_male_adult,
+        get_groupname("Recurve", "Female", "Adult") : recurve_female_adult,
+        get_groupname("Barebow", "Male", "Adult"): barebow_male_adult,
+        get_groupname("Barebow", "Female", "Adult"): barebow_female_adult,
+        get_groupname("Longbow", "Male", "Adult"): longbow_male_adult,
+        get_groupname("Longbow", "Female", "Adult"): longbow_female_adult,
+        get_groupname("Traditional", "Male", "Adult"): traditional_male_adult,
+        get_groupname("Traditional", "Female", "Adult"): traditional_female_adult,
+        get_groupname("Flatbow", "Male", "Adult"): flatbow_male_adult,
+        get_groupname("Flatbow", "Female", "Adult"): flatbow_female_adult,
+        get_groupname("Compound", "Male", "Under 18") : compound_male_u18,
+        get_groupname("Compound", "Female", "Under 18") : compound_female_u18,
+        get_groupname("Recurve", "Male", "Under 18") : recurve_male_u18,
+        get_groupname("Recurve", "Female", "Under 18") : recurve_female_u18,
+        get_groupname("Barebow", "Male", "Under 18") : barebow_male_u18,
+        get_groupname("Barebow", "Female", "Under 18") : barebow_female_u18,
+        get_groupname("Longbow", "Male", "Under 18") : longbow_male_u18,
+        get_groupname("Longbow", "Female", "Under 18") : longbow_female_u18,
+        get_groupname("Traditional", "Male", "Under 18") : traditional_male_u18,
+        get_groupname("Traditional", "Female", "Under 18") : traditional_female_u18,
+        get_groupname("Flatbow", "Male", "Under 18") : flatbow_male_u18,
+        get_groupname("Flatbow", "Female", "Under 18") : flatbow_female_u18,
     }
 
     return classification_dict

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -188,9 +188,7 @@ def calculate_agb_field_classification(
         return "unclassified"
 
     # What is the highest classification this score gets?
-    class_scores = dict(
-        zip(group_data["classes"], group_data["class_scores"])
-    )
+    class_scores = dict(zip(group_data["classes"], group_data["class_scores"]))
     for item in class_scores:
         if class_scores[item] > score:
             pass

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -12,7 +12,7 @@ agb_field_classification_scores
 # pylint: disable=duplicate-code
 
 import re
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 
 from archeryutils import load_rounds
@@ -26,7 +26,7 @@ ALL_AGBFIELD_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_field_classification_dict() -> Dict[str, Dict[str, Any]]:
+def _make_agb_field_classification_dict() -> dict[str, dict[str, Any]]:
     """
     Generate AGB outdoor classification data.
 
@@ -262,7 +262,7 @@ def calculate_agb_field_classification(
         return "unclassified"
 
     # What is the highest classification this score gets?
-    class_scores: Dict[str, Any] = dict(
+    class_scores: dict[str, Any] = dict(
         zip(group_data["classes"], group_data["class_scores"])
     )
     for item in class_scores:
@@ -277,7 +277,7 @@ def calculate_agb_field_classification(
 
 def agb_field_classification_scores(
     roundname: str, bowstyle: str, gender: str, age_group: str
-) -> List[int]:
+) -> list[int]:
     """
     Calculate AGB field classification scores for category.
 

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -256,10 +256,4 @@ def agb_field_classification_scores(
     group_data = agb_field_classifications[groupname]
 
     # Get scores required on this round for each classification
-    class_scores = group_data["class_scores"]
-
-    # Score threshold should be int (score_for_round called with round=True)
-    # Enforce this for better code and to satisfy mypy
-    int_class_scores = [int(x) for x in class_scores]
-
-    return int_class_scores
+    return group_data["class_scores"]

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -11,7 +11,7 @@ agb_indoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import Any, TypedDict
+from typing import TypedDict
 import numpy as np
 import numpy.typing as npt
 
@@ -196,7 +196,7 @@ def calculate_agb_indoor_classification(
 
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_indoor_classifications[groupname]
-    class_data: dict[str, Any] = dict(zip(group_data["classes"], all_class_scores))
+    class_data = dict(zip(group_data["classes"], all_class_scores))
 
     # What is the highest classification this score gets?
     # < 0 handles max scores, > score handles higher classifications

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -11,7 +11,7 @@ agb_indoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 
 from archeryutils import load_rounds
@@ -27,7 +27,7 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_indoor_classification_dict() -> Dict[str, Dict[str, Any]]:
+def _make_agb_indoor_classification_dict() -> dict[str, dict[str, Any]]:
     """
     Generate new (2023) AGB indoor classification data.
 
@@ -183,7 +183,7 @@ def calculate_agb_indoor_classification(
 
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_indoor_classifications[groupname]
-    class_data: Dict[str, Any] = dict(zip(group_data["classes"], all_class_scores))
+    class_data: dict[str, Any] = dict(zip(group_data["classes"], all_class_scores))
 
     # What is the highest classification this score gets?
     # < 0 handles max scores, > score handles higher classifications
@@ -206,7 +206,7 @@ def agb_indoor_classification_scores(
     bowstyle: str,
     gender: str,
     age_group: str,
-) -> List[int]:
+) -> list[int]:
     """
     Calculate 2023 AGB indoor classification scores for category.
 

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -296,11 +296,6 @@ def agb_indoor_classification_scores(
         for i, class_i in enumerate(group_data["classes"])
     ]
 
-    # Make sure that hc.eq.score_for_round did not return array to satisfy mypy
-    if any(isinstance(x, np.ndarray) for x in class_scores):
-        raise TypeError(
-            "score_for_round is attempting to return an array when float expected."
-        )
     # Score threshold should be int (score_for_round called with round=True)
     # Enforce this for better code and to satisfy mypy
     int_class_scores = [int(x) for x in class_scores]

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -27,7 +27,10 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
     ]
 )
 
+
 class GroupData(TypedDict):
+    """Structure for AGB Indoor classification data."""
+
     classes: list[str]
     classes_long: list[str]
     class_HC: npt.NDArray[np.float_]
@@ -61,6 +64,8 @@ def _make_agb_indoor_classification_dict() -> dict[str, GroupData]:
     # For score purposes in classifications we use the full face, not the triple.
     # Option of having triple is handled in get classification function
     # Compound version of rounds is handled below.
+    # One too many locals, but better than repeated dictionary assignment => disable
+    # pylint: disable=too-many-locals
 
     # Read in age group info as list of dicts
     agb_ages = cls_funcs.read_ages_json()
@@ -107,7 +112,7 @@ def _make_agb_indoor_classification_dict() -> dict[str, GroupData]:
                 groupdata: GroupData = {
                     "classes": agb_classes_in,
                     "classes_long": agb_classes_in_long,
-                    "class_HC": class_hc
+                    "class_HC": class_hc,
                 }
                 classification_dict[groupname] = groupdata
 

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -26,7 +26,10 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
     ]
 )
 
+
 class GroupData(TypedDict):
+    """Structure for old AGB Indoor classification data."""
+
     classes: list[str]
     class_HC: list[int]
 
@@ -75,12 +78,12 @@ def _make_agb_old_indoor_classification_dict() -> dict[str, GroupData]:
     }
 
     classification_dict = {
-        cls_funcs.get_groupname("Compound", "Male", "Adult") : compound_male_adult,
-        cls_funcs.get_groupname("Compound", "Female", "Adult") : compound_female_adult,
-        cls_funcs.get_groupname("Recurve", "Male", "Adult") : recurve_male_adult,
-        cls_funcs.get_groupname("Recurve", "Female", "Adult") : recurve_female_adult,
+        cls_funcs.get_groupname("Compound", "Male", "Adult"): compound_male_adult,
+        cls_funcs.get_groupname("Compound", "Female", "Adult"): compound_female_adult,
+        cls_funcs.get_groupname("Recurve", "Male", "Adult"): recurve_male_adult,
+        cls_funcs.get_groupname("Recurve", "Female", "Adult"): recurve_female_adult,
     }
-    
+
     return classification_dict
 
 

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -11,7 +11,7 @@ AGB_old_indoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import Any, TypedDict
+from typing import TypedDict
 import numpy as np
 
 from archeryutils import load_rounds
@@ -158,7 +158,7 @@ def calculate_agb_old_indoor_classification(
 
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_old_indoor_classifications[groupname]
-    class_data: dict[str, Any] = dict(zip(group_data["classes"], class_scores))
+    class_data = dict(zip(group_data["classes"], class_scores))
 
     # What is the highest classification this score gets?
     to_del = []

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -11,7 +11,7 @@ AGB_old_indoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import Any
+from typing import Any, TypedDict
 import numpy as np
 
 from archeryutils import load_rounds
@@ -26,8 +26,12 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
     ]
 )
 
+class GroupData(TypedDict):
+    classes: list[str]
+    class_HC: list[int]
 
-def _make_agb_old_indoor_classification_dict() -> dict[str, dict[str, Any]]:
+
+def _make_agb_old_indoor_classification_dict() -> dict[str, GroupData]:
     """
     Generate AGB outdoor classification data.
 
@@ -53,24 +57,30 @@ def _make_agb_old_indoor_classification_dict() -> dict[str, dict[str, Any]]:
 
     # Generate dict of classifications
     # for both bowstyles, for both genders
-    classification_dict = {}
-    classification_dict[cls_funcs.get_groupname("Compound", "Male", "Adult")] = {
+    compound_male_adult: GroupData = {
         "classes": agb_indoor_classes,
         "class_HC": [5, 12, 24, 37, 49, 62, 73, 79],
     }
-    classification_dict[cls_funcs.get_groupname("Compound", "Female", "Adult")] = {
+    compound_female_adult: GroupData = {
         "classes": agb_indoor_classes,
         "class_HC": [12, 18, 30, 43, 55, 67, 79, 83],
     }
-    classification_dict[cls_funcs.get_groupname("Recurve", "Male", "Adult")] = {
+    recurve_male_adult: GroupData = {
         "classes": agb_indoor_classes,
         "class_HC": [14, 21, 33, 46, 58, 70, 80, 85],
     }
-    classification_dict[cls_funcs.get_groupname("Recurve", "Female", "Adult")] = {
+    recurve_female_adult: GroupData = {
         "classes": agb_indoor_classes,
         "class_HC": [21, 27, 39, 51, 64, 75, 85, 90],
     }
 
+    classification_dict = {
+        cls_funcs.get_groupname("Compound", "Male", "Adult") : compound_male_adult,
+        cls_funcs.get_groupname("Compound", "Female", "Adult") : compound_female_adult,
+        cls_funcs.get_groupname("Recurve", "Male", "Adult") : recurve_male_adult,
+        cls_funcs.get_groupname("Recurve", "Female", "Adult") : recurve_female_adult,
+    }
+    
     return classification_dict
 
 

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -12,7 +12,6 @@ AGB_old_indoor_classification_scores
 # pylint: disable=duplicate-code
 
 from typing import TypedDict
-import numpy as np
 
 from archeryutils import load_rounds
 from archeryutils.handicaps import handicap_equations as hc_eq
@@ -260,11 +259,6 @@ def agb_old_indoor_classification_scores(
         for i, class_i in enumerate(group_data["classes"])
     ]
 
-    # Make sure that hc.eq.score_for_round did not return array to satisfy mypy
-    if any(isinstance(x, np.ndarray) for x in class_scores):
-        raise TypeError(
-            "score_for_round is attempting to return an array when float expected."
-        )
     # Score threshold should be int (score_for_round called with round=True)
     # Enforce this for better code and to satisfy mypy
     int_class_scores = [int(x) for x in class_scores]

--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -11,7 +11,7 @@ AGB_old_indoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List, Dict, Any
+from typing import Any
 import numpy as np
 
 from archeryutils import load_rounds
@@ -27,7 +27,7 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_old_indoor_classification_dict() -> Dict[str, Dict[str, Any]]:
+def _make_agb_old_indoor_classification_dict() -> dict[str, dict[str, Any]]:
     """
     Generate AGB outdoor classification data.
 
@@ -145,7 +145,7 @@ def calculate_agb_old_indoor_classification(
 
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_old_indoor_classifications[groupname]
-    class_data: Dict[str, Any] = dict(zip(group_data["classes"], class_scores))
+    class_data: dict[str, Any] = dict(zip(group_data["classes"], class_scores))
 
     # What is the highest classification this score gets?
     to_del = []
@@ -170,7 +170,7 @@ def agb_old_indoor_classification_scores(
     bowstyle: str,
     gender: str,
     age_group: str,
-) -> List[int]:
+) -> list[int]:
     """
     Calculate AGB indoor classification scores for category.
 

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -433,7 +433,6 @@ def calculate_agb_outdoor_classification(
         return "UC"
 
 
-
 def _check_prestige_distance(
     roundname: str, groupname: str, class_data: dict[str, dict[str, Any]]
 ) -> dict[str, dict[str, Any]]:

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -31,6 +31,8 @@ ALL_OUTDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 
 
 class GroupData(TypedDict):
+    """Structure for AGB Outdoor classification data."""
+
     classes: list[str]
     max_distance: list[int]
     classes_long: list[str]
@@ -64,6 +66,9 @@ def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
     ArcheryGB 2023 Rules of Shooting
     ArcheryGB Shooting Administrative Procedures - SAP7 (2023)
     """
+    # Five too many locals, but better than repeated dictionary assignment => disable
+    # pylint: disable=too-many-locals
+
     # Read in age group info as list of dicts
     agb_ages = cls_funcs.read_ages_json()
     # Read in bowstyleclass info as list of dicts
@@ -83,16 +88,14 @@ def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
     for bowstyle in agb_bowstyles:
         for gender in agb_genders:
             for age in agb_ages:
-
                 groupname = cls_funcs.get_groupname(
                     bowstyle["bowstyle"], gender, age["age_group"]
                 )
 
                 # Get max dists for category from json file data
                 # Use metres as corresponding yards >= metric
-                gender_key = cast(Literal['male', 'female'], gender.lower())
+                gender_key = cast(Literal["male", "female"], gender.lower())
                 max_dist = age[gender_key]
-
 
                 # set step from datum based on age and gender steps required
                 delta_hc_age_gender = cls_funcs.get_age_gender_step(
@@ -136,7 +139,7 @@ def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
                     "classes_long": agb_classes_out_long,
                     "class_HC": class_hc,
                     "min_dists": min_dists,
-                    "prestige_rounds": prestige_rounds
+                    "prestige_rounds": prestige_rounds,
                 }
 
                 classification_dict[groupname] = groupdata

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -11,9 +11,10 @@ agb_outdoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, TypedDict
 from collections import OrderedDict
 import numpy as np
+import numpy.typing as npt
 
 from archeryutils import load_rounds
 from archeryutils.handicaps import handicap_equations as hc_eq
@@ -29,7 +30,16 @@ ALL_OUTDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
+class GroupData(TypedDict):
+    classes: list[str]
+    max_distance: list[int]
+    classes_long: list[str]
+    class_HC: npt.NDArray[np.float_]
+    min_dists: npt.NDArray[np.float_]
+    prestige_rounds: list[str]
+
+
+def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
     """
     Generate AGB outdoor classification data.
 
@@ -83,11 +93,6 @@ def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
                 gender_key = cast(Literal['male', 'female'], gender.lower())
                 max_dist = age[gender_key]
 
-                classification_dict[groupname] = {
-                    "classes": agb_classes_out,
-                    "max_distance": max_dist,
-                    "classes_long": agb_classes_out_long,
-                }
 
                 # set step from datum based on age and gender steps required
                 delta_hc_age_gender = cls_funcs.get_age_gender_step(
@@ -96,23 +101,21 @@ def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
                     bowstyle["ageStep_out"],
                     bowstyle["genderStep_out"],
                 )
+                classifications_count = len(agb_classes_out)
 
-                classification_dict[groupname]["class_HC"] = np.empty(
-                    len(agb_classes_out)
-                )
-                classification_dict[groupname]["min_dists"] = np.empty(
-                    len(agb_classes_out)
-                )
-                for i in range(len(agb_classes_out)):
+                class_hc = np.empty(classifications_count)
+                min_dists = np.empty(classifications_count)
+
+                for i in range(classifications_count):
                     # Assign handicap for this classification
-                    classification_dict[groupname]["class_HC"][i] = (
+                    class_hc[i] = (
                         bowstyle["datum_out"]
                         + delta_hc_age_gender
                         + (i - 2) * bowstyle["classStep_out"]
                     )
 
                     # Get minimum distance that must be shot for this classification
-                    classification_dict[groupname]["min_dists"][i] = _assign_min_dist(
+                    min_dists[i] = _assign_min_dist(
                         n_class=i,
                         gender=gender,
                         age_group=age["age_group"],
@@ -120,14 +123,23 @@ def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
                     )
 
                 # Assign prestige rounds for the category
-                classification_dict[groupname]["prestige_rounds"] = (
-                    _assign_outdoor_prestige(
-                        bowstyle=bowstyle["bowstyle"],
-                        age=age["age_group"],
-                        gender=gender,
-                        max_dist=max_dist,
-                    )
+                prestige_rounds = _assign_outdoor_prestige(
+                    bowstyle=bowstyle["bowstyle"],
+                    age=age["age_group"],
+                    gender=gender,
+                    max_dist=max_dist,
                 )
+
+                groupdata: GroupData = {
+                    "classes": agb_classes_out,
+                    "max_distance": max_dist,
+                    "classes_long": agb_classes_out_long,
+                    "class_HC": class_hc,
+                    "min_dists": min_dists,
+                    "prestige_rounds": prestige_rounds
+                }
+
+                classification_dict[groupname] = groupdata
 
     return classification_dict
 

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -12,7 +12,6 @@ agb_outdoor_classification_scores
 # pylint: disable=duplicate-code
 
 from typing import Any, Literal, cast, TypedDict
-from collections import OrderedDict
 import numpy as np
 import numpy.typing as npt
 
@@ -408,8 +407,8 @@ def calculate_agb_outdoor_classification(
     groupname = cls_funcs.get_groupname(bowstyle, gender, age_group)
     group_data = agb_outdoor_classifications[groupname]
 
-    # We iterate over class_data keys, so convert use OrderedDict
-    class_data: OrderedDict[str, dict[str, Any]] = OrderedDict([])
+    # dictionary ordering guaranteed in python 3.7+
+    class_data = {}
     for i, class_i in enumerate(group_data["classes"]):
         class_data[class_i] = {
             "min_dist": group_data["min_dists"][i],
@@ -434,10 +433,10 @@ def calculate_agb_outdoor_classification(
         return "UC"
 
 
-def _check_prestige_distance(
-    roundname: str, groupname: str, class_data: OrderedDict[str, dict[str, Any]]
-) -> OrderedDict[str, dict[str, Any]]:
 
+def _check_prestige_distance(
+    roundname: str, groupname: str, class_data: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
     """
     Check available classifications for eligibility based on distance and prestige..
 
@@ -450,12 +449,12 @@ def _check_prestige_distance(
         name of round shot as given by 'codename' in json
     groupname : str
         identifier for the category
-    class_data : OrderedDict
+    class_data : dict
         classification information for each category.
 
     Returns
     -------
-    class_data : OrderedDict
+    class_data : dict
         updated classification information for each category.
 
     References

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -562,11 +562,6 @@ def agb_outdoor_classification_scores(
             if group_data["min_dists"][i] > round_max_dist:
                 class_scores[i] = -9999
 
-    # Make sure that hc.eq.score_for_round did not return array to satisfy mypy
-    if any(isinstance(x, np.ndarray) for x in class_scores):
-        raise TypeError(
-            "score_for_round is attempting to return an array when float expected."
-        )
     # Score threshold should be int (score_for_round called with round=True)
     # Enforce this for better code and to satisfy mypy
     int_class_scores = [int(x) for x in class_scores]

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -11,7 +11,7 @@ agb_outdoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List, Dict, Any
+from typing import Any
 from collections import OrderedDict
 import numpy as np
 
@@ -29,7 +29,7 @@ ALL_OUTDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 )
 
 
-def _make_agb_outdoor_classification_dict() -> Dict[str, Dict[str, Any]]:
+def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
     """
     Generate AGB outdoor classification data.
 
@@ -134,7 +134,7 @@ def _assign_min_dist(
     n_class: int,
     gender: str,
     age_group: str,
-    max_dists: List[int],
+    max_dists: list[int],
 ) -> int:
     """
     Assign appropriate minimum distance required for a category and classification.
@@ -203,8 +203,8 @@ def _assign_outdoor_prestige(
     bowstyle: str,
     gender: str,
     age: str,
-    max_dist: List[int],
-) -> List[str]:
+    max_dist: list[int],
+) -> list[str]:
     """
     Assign appropriate outdoor prestige rounds for a category.
 
@@ -277,7 +277,7 @@ def _assign_outdoor_prestige(
     # Assign prestige rounds for the category
     #  - check bowstyle, distance, and age
     prestige_rounds = []
-    distance_check: List[str] = []
+    distance_check: list[str] = []
 
     # 720 rounds - bowstyle dependent
     if bowstyle.lower() == "compound":
@@ -392,7 +392,7 @@ def calculate_agb_outdoor_classification(
     group_data = agb_outdoor_classifications[groupname]
 
     # We iterate over class_data keys, so convert use OrderedDict
-    class_data: OrderedDict[str, Dict[str, Any]] = OrderedDict([])
+    class_data: OrderedDict[str, dict[str, Any]] = OrderedDict([])
     for i, class_i in enumerate(group_data["classes"]):
         class_data[class_i] = {
             "min_dist": group_data["min_dists"][i],
@@ -418,8 +418,9 @@ def calculate_agb_outdoor_classification(
 
 
 def _check_prestige_distance(
-    roundname: str, groupname: str, class_data: OrderedDict[str, Dict[str, Any]]
-) -> OrderedDict[str, Dict[str, Any]]:
+    roundname: str, groupname: str, class_data: OrderedDict[str, dict[str, Any]]
+) -> OrderedDict[str, dict[str, Any]]:
+
     """
     Check available classifications for eligibility based on distance and prestige..
 
@@ -451,7 +452,7 @@ def _check_prestige_distance(
             del class_data[mb_class]
 
         # If not prestige, what classes are ineligible based on distance
-        to_del: List[str] = []
+        to_del: list[str] = []
         round_max_dist = ALL_OUTDOOR_ROUNDS[roundname].max_distance()
         for class_i_name, class_i_data in class_data.items():
             if class_i_data["min_dist"] > round_max_dist:
@@ -464,7 +465,7 @@ def _check_prestige_distance(
 
 def agb_outdoor_classification_scores(
     roundname: str, bowstyle: str, gender: str, age_group: str
-) -> List[int]:
+) -> list[int]:
     """
     Calculate AGB outdoor classification scores for category.
 

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -11,7 +11,7 @@ agb_outdoor_classification_scores
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import Any
+from typing import Any, Literal, cast
 from collections import OrderedDict
 import numpy as np
 
@@ -73,13 +73,15 @@ def _make_agb_outdoor_classification_dict() -> dict[str, dict[str, Any]]:
     for bowstyle in agb_bowstyles:
         for gender in agb_genders:
             for age in agb_ages:
+
                 groupname = cls_funcs.get_groupname(
                     bowstyle["bowstyle"], gender, age["age_group"]
                 )
 
                 # Get max dists for category from json file data
                 # Use metres as corresponding yards >= metric
-                max_dist = age[gender.lower()]
+                gender_key = cast(Literal['male', 'female'], gender.lower())
+                max_dist = age[gender_key]
 
                 classification_dict[groupname] = {
                     "classes": agb_classes_out,

--- a/archeryutils/classifications/classification_utils.py
+++ b/archeryutils/classifications/classification_utils.py
@@ -15,12 +15,12 @@ get_compound_codename
 
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Any
 
 
 def read_ages_json(
     age_file: Path = Path(__file__).parent / "AGB_ages.json",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Read AGB age categories in from neighbouring json file to list of dicts.
 
@@ -55,7 +55,7 @@ def read_ages_json(
 
 def read_bowstyles_json(
     bowstyles_file: Path = Path(__file__).parent / "AGB_bowstyles.json",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Read AGB  bowstyles in from neighbouring json file to list of dicts.
 
@@ -90,7 +90,7 @@ def read_bowstyles_json(
 
 def read_genders_json(
     genders_file: Path = Path(__file__).parent / "AGB_genders.json",
-) -> List[str]:
+) -> list[str]:
     """
     Read AGB genders in from neighbouring json file to list of dict.
 
@@ -126,7 +126,7 @@ def read_genders_json(
 
 def read_classes_json(
     class_system: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Read AGB classes in from neighbouring json file to dict.
 

--- a/archeryutils/classifications/classification_utils.py
+++ b/archeryutils/classifications/classification_utils.py
@@ -15,15 +15,17 @@ get_compound_codename
 
 import json
 from pathlib import Path
-from typing import Any, TypedDict, Literal
+from typing import TypedDict, Literal
+
 
 class AGBAgeData(TypedDict):
     """Structure for AGB age group data."""
-    desc : str
-    age_group : str
-    male : list[int]
-    female : list[int]
-    step : int
+
+    desc: str
+    age_group: str
+    male: list[int]
+    female: list[int]
+    step: int
 
 
 def read_ages_json(
@@ -60,17 +62,19 @@ def read_ages_json(
         f"Expected list(dict()) but got {type(ages)}. Check {age_file}."
     )
 
+
 class AGBBowstyleData(TypedDict):
     """Structure for AGB bowstyle data."""
-    bowstyle : str
-    datum_out : float
-    classStep_out : float
-    genderStep_out : float
-    ageStep_out : float
-    datum_in : float
-    classStep_in : float
-    genderStep_in : float
-    ageStep_in : float
+
+    bowstyle: str
+    datum_out: float
+    classStep_out: float
+    genderStep_out: float
+    ageStep_out: float
+    datum_in: float
+    classStep_in: float
+    genderStep_in: float
+    ageStep_in: float
 
 
 def read_bowstyles_json(
@@ -146,6 +150,7 @@ def read_genders_json(
 
 class AGBClassificationData(TypedDict):
     """Structure for AGB classification name data."""
+
     location: str
     classes: list[str]
     classes_long: list[str]

--- a/archeryutils/classifications/classification_utils.py
+++ b/archeryutils/classifications/classification_utils.py
@@ -15,12 +15,20 @@ get_compound_codename
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict, Literal
+
+class AGBAgeData(TypedDict):
+    """Structure for AGB age group data."""
+    desc : str
+    age_group : str
+    male : list[int]
+    female : list[int]
+    step : int
 
 
 def read_ages_json(
     age_file: Path = Path(__file__).parent / "AGB_ages.json",
-) -> list[dict[str, Any]]:
+) -> list[AGBAgeData]:
     """
     Read AGB age categories in from neighbouring json file to list of dicts.
 
@@ -52,10 +60,22 @@ def read_ages_json(
         f"Expected list(dict()) but got {type(ages)}. Check {age_file}."
     )
 
+class AGBBowstyleData(TypedDict):
+    """Structure for AGB bowstyle data."""
+    bowstyle : str
+    datum_out : float
+    classStep_out : float
+    genderStep_out : float
+    ageStep_out : float
+    datum_in : float
+    classStep_in : float
+    genderStep_in : float
+    ageStep_in : float
+
 
 def read_bowstyles_json(
     bowstyles_file: Path = Path(__file__).parent / "AGB_bowstyles.json",
-) -> list[dict[str, Any]]:
+) -> list[AGBBowstyleData]:
     """
     Read AGB  bowstyles in from neighbouring json file to list of dicts.
 
@@ -90,7 +110,7 @@ def read_bowstyles_json(
 
 def read_genders_json(
     genders_file: Path = Path(__file__).parent / "AGB_genders.json",
-) -> list[str]:
+) -> list[Literal["Male", "Female"]]:
     """
     Read AGB genders in from neighbouring json file to list of dict.
 
@@ -124,9 +144,16 @@ def read_genders_json(
     )
 
 
+class AGBClassificationData(TypedDict):
+    """Structure for AGB classification name data."""
+    location: str
+    classes: list[str]
+    classes_long: list[str]
+
+
 def read_classes_json(
     class_system: str,
-) -> dict[str, Any]:
+) -> AGBClassificationData:
     """
     Read AGB classes in from neighbouring json file to dict.
 
@@ -168,7 +195,7 @@ def read_classes_json(
 
     # Read in classification names as dict
     with open(classes_file, encoding="utf-8") as json_file:
-        classes = json.load(json_file)
+        classes: AGBClassificationData = json.load(json_file)
     if isinstance(classes, dict):
         return classes
     raise TypeError(

--- a/archeryutils/classifications/tests/test_agb_field.py
+++ b/archeryutils/classifications/tests/test_agb_field.py
@@ -4,7 +4,6 @@
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List
 import pytest
 
 from archeryutils import load_rounds
@@ -68,7 +67,7 @@ class TestAgbFieldClassificationScores:
         self,
         roundname: str,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that field classification returns expected value for a case.
@@ -116,7 +115,7 @@ class TestAgbFieldClassificationScores:
         roundname: str,
         gender: str,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that field classification returns expected value for a case.
@@ -170,7 +169,7 @@ class TestAgbFieldClassificationScores:
         self,
         roundname: str,
         bowstyle: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that field classification returns expected value for a case.

--- a/archeryutils/classifications/tests/test_agb_indoor.py
+++ b/archeryutils/classifications/tests/test_agb_indoor.py
@@ -4,7 +4,6 @@
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List
 import pytest
 
 from archeryutils import load_rounds
@@ -82,7 +81,7 @@ class TestAgbIndoorClassificationScores:
     def test_agb_indoor_classification_scores_ages(
         self,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that  classification returns expected value for a case.
@@ -120,7 +119,7 @@ class TestAgbIndoorClassificationScores:
     def test_agb_indoor_classification_scores_genders(
         self,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that indoor classification returns expected value for a case.
@@ -157,7 +156,7 @@ class TestAgbIndoorClassificationScores:
     def test_agb_indoor_classification_scores_bowstyles(
         self,
         bowstyle: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that indoor classification returns expected value for a case.
@@ -191,7 +190,7 @@ class TestAgbIndoorClassificationScores:
     def test_agb_indoor_classification_scores_nonbowstyles(
         self,
         bowstyle: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that barebow scores returned for valid but non-indoor styles.
@@ -225,7 +224,7 @@ class TestAgbIndoorClassificationScores:
     def test_agb_indoor_classification_scores_triple_faces(
         self,
         roundname: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that indoor classification returns single face scores only.

--- a/archeryutils/classifications/tests/test_agb_old_indoor.py
+++ b/archeryutils/classifications/tests/test_agb_old_indoor.py
@@ -4,7 +4,6 @@
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List
 import pytest
 
 from archeryutils import load_rounds
@@ -65,7 +64,7 @@ class TestAgbOldIndoorClassificationScores:
     def test_agb_old_indoor_classification_scores_ages(
         self,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that old_indoor classification returns expected value for a case.
@@ -114,7 +113,7 @@ class TestAgbOldIndoorClassificationScores:
         self,
         bowstyle: str,
         gender: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that old_indoor classification returns expected value for a case.

--- a/archeryutils/classifications/tests/test_agb_outdoor.py
+++ b/archeryutils/classifications/tests/test_agb_outdoor.py
@@ -4,7 +4,6 @@
 # => disable for classification files and tests
 # pylint: disable=duplicate-code
 
-from typing import List
 import pytest
 
 from archeryutils import load_rounds
@@ -92,7 +91,7 @@ class TestAgbOutdoorClassificationScores:
         self,
         roundname: str,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that  classification returns expected value for a case.
@@ -135,7 +134,7 @@ class TestAgbOutdoorClassificationScores:
         self,
         roundname: str,
         age_group: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that outdoor classification returns expected value for a case.
@@ -198,7 +197,7 @@ class TestAgbOutdoorClassificationScores:
         roundname: str,
         bowstyle: str,
         gender: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that outdoor classification returns expected value for a case.
@@ -240,7 +239,7 @@ class TestAgbOutdoorClassificationScores:
         roundname: str,
         bowstyle: str,
         gender: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that barebow scores returned for valid but non-outdoor bowstyles.
@@ -266,7 +265,7 @@ class TestAgbOutdoorClassificationScores:
     def test_agb_outdoor_classification_scores_triple_faces(
         self,
         roundname: str,
-        scores_expected: List[int],
+        scores_expected: list[int],
     ) -> None:
         """
         Check that outdoor classification returns single face scores only.

--- a/archeryutils/handicaps/handicap_equations.py
+++ b/archeryutils/handicaps/handicap_equations.py
@@ -46,6 +46,7 @@ References
   https://doi.org/10.1177%2F1754337114539308
 
 """
+
 import json
 from typing import Optional, TypeVar
 

--- a/archeryutils/handicaps/handicap_equations.py
+++ b/archeryutils/handicaps/handicap_equations.py
@@ -55,7 +55,8 @@ import numpy.typing as npt
 
 from archeryutils import targets, rounds
 
-FloatArray = TypeVar('FloatArray', float, np.float_, npt.NDArray[np.float_])
+FloatArray = TypeVar("FloatArray", float, np.float_, npt.NDArray[np.float_])
+
 
 @dataclass
 class HcParams:

--- a/archeryutils/handicaps/handicap_equations.py
+++ b/archeryutils/handicaps/handicap_equations.py
@@ -215,7 +215,6 @@ def sigma_t(
     array([0.00094983, 0.00376062, 0.02100276])
 
     """
-
     if hc_sys == "AGB":
         # New AGB (Archery GB) System
         # Written by Jack Atkinson

--- a/archeryutils/handicaps/handicap_equations.py
+++ b/archeryutils/handicaps/handicap_equations.py
@@ -46,15 +46,16 @@ References
   https://doi.org/10.1177%2F1754337114539308
 
 """
-
 import json
-from typing import Union, Optional
+from typing import Optional, TypeVar
+
 from dataclasses import dataclass, field
 import numpy as np
 import numpy.typing as npt
 
 from archeryutils import targets, rounds
 
+FloatArray = TypeVar('FloatArray', float, np.float_, npt.NDArray[np.float_])
 
 @dataclass
 class HcParams:
@@ -169,11 +170,11 @@ class HcParams:
 
 
 def sigma_t(
-    handicap: Union[float, npt.NDArray[np.float_]],
+    handicap: FloatArray,
     hc_sys: str,
     dist: float,
     hc_dat: HcParams,
-) -> Union[float, np.float_, npt.NDArray[np.float_]]:
+) -> FloatArray:
     """
     Calculate angular deviation for given scheme, handicap, and distance.
 
@@ -214,8 +215,6 @@ def sigma_t(
     array([0.00094983, 0.00376062, 0.02100276])
 
     """
-    # Declare sig_t type for mypy
-    sig_t: Union[float, npt.NDArray[np.float_]]
 
     if hc_sys == "AGB":
         # New AGB (Archery GB) System
@@ -285,11 +284,11 @@ def sigma_t(
 
 
 def sigma_r(
-    handicap: Union[float, npt.NDArray[np.float_]],
+    handicap: FloatArray,
     hc_sys: str,
     dist: float,
     hc_dat: HcParams,
-) -> Union[float, np.float_, npt.NDArray[np.float_]]:
+) -> FloatArray:
     """
     Calculate deviation for a given scheme and handicap value.
 
@@ -337,11 +336,11 @@ def sigma_r(
 
 def arrow_score(
     target: targets.Target,
-    handicap: Union[float, npt.NDArray[np.float_]],
+    handicap: FloatArray,
     hc_sys: str,
     hc_dat: HcParams,
     arw_d: Optional[float] = None,
-) -> Union[float, np.float_, npt.NDArray[np.float_]]:
+) -> FloatArray:
     # Six too many branches. Makes sense due to different target faces => disable
     # pylint: disable=too-many-branches
     """
@@ -516,7 +515,7 @@ def arrow_score(
 
 def score_for_passes(
     rnd: rounds.Round,
-    handicap: Union[float, npt.NDArray[np.float_]],
+    handicap: FloatArray,
     hc_sys: str,
     hc_dat: HcParams,
     arw_d: Optional[float] = None,
@@ -579,12 +578,12 @@ def score_for_passes(
 
 def score_for_round(
     rnd: rounds.Round,
-    handicap: Union[float, npt.NDArray[np.float_]],
+    handicap: FloatArray,
     hc_sys: str,
     hc_dat: HcParams,
     arw_d: Optional[float] = None,
     round_score_up: bool = True,
-) -> Union[float, np.float_, npt.NDArray[np.float_]]:
+) -> FloatArray:
     """
     Calculate the expected score for a round at a given handicap rating.
 

--- a/archeryutils/handicaps/handicap_functions.py
+++ b/archeryutils/handicaps/handicap_functions.py
@@ -26,7 +26,7 @@ Routine Listings
 
 """
 
-from typing import Union, Optional, List
+from typing import Union, Optional
 import warnings
 from itertools import chain
 import decimal
@@ -40,7 +40,7 @@ _FILL = -9999
 
 
 def handicap_from_score(
-    score: Union[int, float],
+    score: float,
     rnd: rounds.Round,
     hc_sys: str,
     hc_dat: hc_eq.HcParams,
@@ -153,7 +153,7 @@ def get_max_score_handicap(
     hc_dat: hc_eq.HcParams,
     arw_d: Optional[float],
     int_prec: bool = False,
-) -> float:
+) -> Union[int, float]:
     """
     Get handicap for maximum score on a round.
 
@@ -354,7 +354,7 @@ def rootfind_score_handicap(
 
 def f_root(
     hc_est: float,
-    score_est: Union[int, float],
+    score_est: float,
     round_est: rounds.Round,
     sys: str,
     hc_data: hc_eq.HcParams,
@@ -413,7 +413,7 @@ def f_root(
 def print_handicap_table(
     hcs: Union[float, NDArray[np.float_]],
     hc_sys: str,
-    round_list: List[rounds.Round],
+    round_list: list[rounds.Round],
     hc_dat: hc_eq.HcParams,
     arrow_d: Optional[float] = None,
     round_scores_up: bool = True,
@@ -669,7 +669,7 @@ def abbreviate(name: str) -> str:
 
 
 def table_as_str(
-    round_list: List[rounds.Round],
+    round_list: list[rounds.Round],
     hcs: NDArray[Union[np.float_, np.int_]],
     table: NDArray[Union[np.float_, np.int_]],
     int_prec: bool = False,

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -349,7 +349,7 @@ class TestArrowScore:
         ):
             target = Target("5_zone", 122.0, 100.0)
             # Silence mypy as scoring_system must be a valid literal ScoringSystem
-            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
+            target.scoring_system = "InvalidScoringSystem"  # type: ignore[assignment]
 
             hc_eq.arrow_score(
                 target=target,

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -4,7 +4,6 @@
 # => disable for handicap tests
 # pylint: disable=duplicate-code
 
-from typing import Tuple, List
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
@@ -481,7 +480,7 @@ class TestScoreForRound:
         ],
     )
     def test_float_round_score(
-        self, hc_system: str, round_score_expected: Tuple[float, List[float]]
+        self, hc_system: str, round_score_expected: tuple[float, list[float]]
     ) -> None:
         """
         Check appropriate expected round scores are returned not rounding.
@@ -515,7 +514,7 @@ class TestScoreForRound:
         ],
     )
     def test_rounded_round_score(
-        self, hc_system: str, round_score_expected: Tuple[float, List[float]]
+        self, hc_system: str, round_score_expected: tuple[float, list[float]]
     ) -> None:
         """
         Check appropriate expected round scores are returned for rounding.

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture
 
 import archeryutils.handicaps.handicap_equations as hc_eq
 import archeryutils.handicaps.handicap_functions as hc_func
-from archeryutils.targets import Target
+from archeryutils.targets import Target, ScoringSystem
 from archeryutils.rounds import Round, Pass
 
 
@@ -348,7 +348,7 @@ class TestArrowScore:
             match="No rule for calculating scoring for face type (.+).",
         ):
             target = Target("5_zone", 122.0, 100.0)
-            target.scoring_system = "InvalidScoringSystem"
+            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
 
             hc_eq.arrow_score(
                 target=target,
@@ -414,7 +414,7 @@ class TestArrowScore:
         ],
     )
     def test_different_target_faces(
-        self, target_face: str, arrow_score_expected: float
+        self, target_face: ScoringSystem, arrow_score_expected: float
     ) -> None:
         """
         Check correct arrow scores returned for different target faces

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -348,6 +348,7 @@ class TestArrowScore:
             match="No rule for calculating scoring for face type (.+).",
         ):
             target = Target("5_zone", 122.0, 100.0)
+            # Silence mypy as scoring_system must be a valid literal ScoringSystem
             target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
 
             hc_eq.arrow_score(

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -3,12 +3,12 @@
 import json
 from pathlib import Path
 import warnings
-from typing import Union, List, Dict, Any
+from typing import Union, Any
 
 from archeryutils.rounds import Pass, Round
 
 
-def read_json_to_round_dict(json_filelist: Union[str, List[str]]) -> Dict[str, Round]:
+def read_json_to_round_dict(json_filelist: Union[str, list[str]]) -> dict[str, Round]:
     """
     Read round information from a json file into a dictionary of rounds.
 
@@ -130,7 +130,7 @@ def read_json_to_round_dict(json_filelist: Union[str, List[str]]) -> Dict[str, R
     return round_dict
 
 
-class DotDict(Dict[str, Any]):
+class DotDict(dict[str, Any]):
     """
     A subclass of dict to provide dot notation access to a dictionary.
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,5 +1,6 @@
 """Module to define a Pass and Round classes for archery applications."""
 from typing import Optional, Union
+from collections.abc import Iterable
 
 from archeryutils.targets import Target, ScoringSystem
 from archeryutils.constants import Length
@@ -158,13 +159,13 @@ class Round:
     def __init__(
         self,
         name: str,
-        passes: list[Pass],
+        passes: Iterable[Pass],
         location: Optional[str] = None,
         body: Optional[str] = None,
         family: Optional[str] = None,
     ) -> None:
         self.name = name
-        self.passes = passes
+        self.passes = list(passes)
         self.location = location
         self.body = body
         self.family = family

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -57,8 +57,8 @@ class Pass:
         self,
         n_arrows: int,
         scoring_system: ScoringSystem,
-        diameter: Union[float, tuple[float,str]],
-        distance: Union[float, tuple[float,str]],
+        diameter: Union[float, tuple[float, str]],
+        distance: Union[float, tuple[float, str]],
         indoor: bool = False,
     ) -> None:
         self.n_arrows = abs(n_arrows)
@@ -181,7 +181,7 @@ class Round:
         """
         return sum(pass_i.max_score() for pass_i in self.passes)
 
-    def max_distance(self, unit: bool = False) -> Union[float, tuple[float,str]]:
+    def max_distance(self, unit: bool = False) -> Union[float, tuple[float, str]]:
         """
         Return the maximum distance shot on this round along with the unit (optional).
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -153,8 +153,8 @@ class Round:
     they will be stored as a list:
 
     >>> my720round = au.Round("WA 720", [my720pass, my720pass])
-    >>> my720round = au.Round("WA 720", (my720pass, my720pass))
-    >>> my720round.passes == [my720pass, my720pass]
+    >>> my720round2 = au.Round("WA 720", (my720pass, my720pass))
+    >>> assert(my720round.passes == my720round2.passes == [my720pass, my720pass])
 
     Additional, optional parameters can be used to provide 'metadata' about the round.
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -19,8 +19,11 @@ class Pass:
     ----------
     n_arrows : int
         number of arrows in this pass.
-    scoring_system : str
-        target face/scoring system type.
+    scoring_system : {\
+        ``"5_zone"`` ``"10_zone"`` ``"10_zone_compound"`` ``"10_zone_6_ring"``\
+        ``"10_zone_5_ring"`` ``"10_zone_5_ring_compound"`` ``"WA_field"`` ``"IFAA_field"``\
+        ``"IFAA_field_expert"`` ``"Beiter_hit_miss"`` ``"Worcester"`` ``"Worcester_2_ring"``}
+        target face/scoring system type. Must be one of the supported values.
     diameter : float or tuple of float, str
         face diameter in [centimetres].
     distance : float or tuple of float, str

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,6 +1,5 @@
 """Module to define a Pass and Round classes for archery applications."""
-
-from typing import List, Union, Tuple
+from typing import Optional, Union
 
 from archeryutils.targets import Target
 from archeryutils.constants import Length
@@ -57,8 +56,8 @@ class Pass:
         self,
         n_arrows: int,
         scoring_system: str,
-        diameter: Union[float, Tuple[float, str]],
-        distance: Union[float, Tuple[float, str]],
+        diameter: Union[float, tuple[float,str]],
+        distance: Union[float, tuple[float,str]],
         indoor: bool = False,
     ) -> None:
         self.n_arrows = abs(n_arrows)
@@ -159,10 +158,10 @@ class Round:
     def __init__(
         self,
         name: str,
-        passes: List[Pass],
-        location: Union[str, None] = None,
-        body: Union[str, None] = None,
-        family: Union[str, None] = None,
+        passes: list[Pass],
+        location: Optional[str] = None,
+        body: Optional[str] = None,
+        family: Optional[str] = None,
     ) -> None:
         self.name = name
         self.passes = passes
@@ -181,7 +180,7 @@ class Round:
         """
         return sum(pass_i.max_score() for pass_i in self.passes)
 
-    def max_distance(self, unit: bool = False) -> Union[float, Tuple[float, str]]:
+    def max_distance(self, unit: bool = False) -> Union[float, tuple[float,str]]:
         """
         Return the maximum distance shot on this round along with the unit (optional).
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -64,7 +64,7 @@ class Pass:
         self.target = Target(scoring_system, diameter, distance, indoor)
 
     @property
-    def scoring_system(self) -> str:
+    def scoring_system(self) -> ScoringSystem:
         """Get target scoring_system."""
         return self.target.scoring_system
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,4 +1,5 @@
 """Module to define a Pass and Round classes for archery applications."""
+
 from typing import Optional, Union
 from collections.abc import Iterable
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -118,8 +118,8 @@ class Round:
     ----------
     name : str
         Formal name of the round
-    passes : list of Pass
-        a list of Pass classes making up the round
+    passes : iterable of Pass
+        an iterable of Pass classes making up the round
     location : str or None, default=None
         string identifing where the round is shot
     body : str or None, default=None
@@ -146,9 +146,12 @@ class Round:
 
     >>> my720pass = au.Pass(36, "10_zone", 122, 70.0)
 
-    These can now be passed to the Round constructor as a list:
+    These can now be passed to the Round constructor as any iterable, 
+    they will be stored as a list:
 
     >>> my720round = au.Round("WA 720", [my720pass, my720pass])
+    >>> my720round = au.Round("WA 720", (my720pass, my720pass))
+    >>> my720round.passes == [my720pass, my720pass]
 
     Additional, optional parameters can be used to provide 'metadata' about the round.
 

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -1,7 +1,7 @@
 """Module to define a Pass and Round classes for archery applications."""
 from typing import Optional, Union
 
-from archeryutils.targets import Target
+from archeryutils.targets import Target, ScoringSystem
 from archeryutils.constants import Length
 
 
@@ -55,7 +55,7 @@ class Pass:
     def __init__(
         self,
         n_arrows: int,
-        scoring_system: str,
+        scoring_system: ScoringSystem,
         diameter: Union[float, tuple[float,str]],
         distance: Union[float, tuple[float,str]],
         indoor: bool = False,

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -146,7 +146,7 @@ class Round:
 
     >>> my720pass = au.Pass(36, "10_zone", 122, 70.0)
 
-    These can now be passed to the Round constructor as any iterable, 
+    These can now be passed to the Round constructor as any iterable,
     they will be stored as a list:
 
     >>> my720round = au.Round("WA 720", [my720pass, my720pass])

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -28,9 +28,9 @@ class Target:
     Parameters
     ----------
     scoring_system : {\
-        "5_zone", "10_zone", "10_zone_compound", "10_zone_6_ring",\
-        "10_zone_5_ring", "10_zone_5_ring_compound", "WA_field", "IFAA_field",\
-        "IFAA_field_expert", "Beiter_hit_miss", "Worcester", "Worcester_2_ring"}
+        ``"5_zone"`` ``"10_zone"`` ``"10_zone_compound"`` ``"10_zone_6_ring"``\
+        ``"10_zone_5_ring"`` ``"10_zone_5_ring_compound"`` ``"WA_field"`` ``"IFAA_field"``\
+        ``"IFAA_field_expert"`` ``"Beiter_hit_miss"`` ``"Worcester"`` ``"Worcester_2_ring"``}
         target face/scoring system type. Must be one of the supported values.
     diameter : float or tuple of float, str
         Target face diameter default [centimetres].

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,9 +1,10 @@
 """Module for representing a Target for archery applications."""
-from typing import Union, TypeAlias, Literal, get_args
+from typing import Union, Literal, get_args
 
 from archeryutils.constants import Length
 
-ScoringSystem: TypeAlias = Literal[
+# TypeAlias (annotate explicitly in py3.10+)
+ScoringSystem = Literal[
     "5_zone",
     "10_zone",
     "10_zone_compound",

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -19,6 +19,7 @@ ScoringSystem = Literal[
     "Worcester_2_ring",
 ]
 
+
 class Target:
     """
     Class to represent a target.
@@ -73,8 +74,8 @@ class Target:
     def __init__(
         self,
         scoring_system: ScoringSystem,
-        diameter: Union[float, tuple[float,str]],
-        distance: Union[float, tuple[float,str]],
+        diameter: Union[float, tuple[float, str]],
+        distance: Union[float, tuple[float, str]],
         indoor: bool = False,
     ) -> None:
         systems = get_args(ScoringSystem)

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,8 +1,22 @@
 """Module for representing a Target for archery applications."""
-from typing import Union
+from typing import Union, TypeAlias, Literal
 
 from archeryutils.constants import Length
 
+ScoringSystem: TypeAlias = Literal[
+    "5_zone",
+    "10_zone",
+    "10_zone_compound",
+    "10_zone_6_ring",
+    "10_zone_5_ring",
+    "10_zone_5_ring_compound",
+    "WA_field",
+    "IFAA_field",
+    "IFAA_field_expert",
+    "Beiter_hit_miss",
+    "Worcester",
+    "Worcester_2_ring",
+]
 
 class Target:
     """
@@ -57,7 +71,7 @@ class Target:
 
     def __init__(
         self,
-        scoring_system: str,
+        scoring_system: ScoringSystem,
         diameter: Union[float, tuple[float,str]],
         distance: Union[float, tuple[float,str]],
         indoor: bool = False,

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,4 +1,5 @@
 """Module for representing a Target for archery applications."""
+
 from typing import Union, Literal, get_args
 
 from archeryutils.constants import Length

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,5 +1,5 @@
 """Module for representing a Target for archery applications."""
-from typing import Union, TypeAlias, Literal
+from typing import Union, TypeAlias, Literal, get_args
 
 from archeryutils.constants import Length
 
@@ -76,20 +76,7 @@ class Target:
         distance: Union[float, tuple[float,str]],
         indoor: bool = False,
     ) -> None:
-        systems = [
-            "5_zone",
-            "10_zone",
-            "10_zone_compound",
-            "10_zone_6_ring",
-            "10_zone_5_ring",
-            "10_zone_5_ring_compound",
-            "WA_field",
-            "IFAA_field",
-            "IFAA_field_expert",
-            "Beiter_hit_miss",
-            "Worcester",
-            "Worcester_2_ring",
-        ]
+        systems = get_args(ScoringSystem)
 
         if scoring_system not in systems:
             raise ValueError(

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -27,8 +27,11 @@ class Target:
 
     Parameters
     ----------
-    scoring_system : str
-        target face/scoring system type.
+    scoring_system : {\
+        "5_zone", "10_zone", "10_zone_compound", "10_zone_6_ring",\
+        "10_zone_5_ring", "10_zone_5_ring_compound", "WA_field", "IFAA_field",\
+        "IFAA_field_expert", "Beiter_hit_miss", "Worcester", "Worcester_2_ring"}
+        target face/scoring system type. Must be one of the supported values.
     diameter : float or tuple of float, str
         Target face diameter default [centimetres].
     distance : float or tuple of float, str
@@ -38,7 +41,7 @@ class Target:
 
     Attributes
     ----------
-    scoring_system : str
+    scoring_system : ScoringSystem
         target face/scoring system type.
     diameter : float
         Target face diameter [metres].
@@ -70,6 +73,14 @@ class Target:
     Indoor rounds can be flagged as such using the `indoor` parameter:
 
     >>> myWA18target = au.Target("10_zone", (40, "cm"), (18.0, "m"), indoor=True)
+
+    Attempting to construct a target with an invalid scoring system will fail
+    in type checking and at runtime.
+
+    >>> myUnknownTarget = au.Target("Unknown", 100, 50)
+    ValueError: Invalid Target Face Type specified.
+
+    # mypy error: Argument 1 to "Target" has incompatible type "Literal['Unkown']"
     """
 
     def __init__(

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -1,6 +1,5 @@
 """Module for representing a Target for archery applications."""
-
-from typing import Union, Tuple
+from typing import Union
 
 from archeryutils.constants import Length
 
@@ -59,8 +58,8 @@ class Target:
     def __init__(
         self,
         scoring_system: str,
-        diameter: Union[float, Tuple[float, str]],
-        distance: Union[float, Tuple[float, str]],
+        diameter: Union[float, tuple[float,str]],
+        distance: Union[float, tuple[float,str]],
         indoor: bool = False,
     ) -> None:
         systems = [

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -79,8 +79,8 @@ class Target:
 
     >>> myUnknownTarget = au.Target("Unknown", 100, 50)
     ValueError: Invalid Target Face Type specified.
+    Please select from '5_zone', '10_zone', '10_zone_compound', '10_zone_6_ring', ...
 
-    # mypy error: Argument 1 to "Target" has incompatible type "Literal['Unkown']"
     """
 
     def __init__(

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -6,6 +6,7 @@ import pytest
 from archeryutils.rounds import Pass, Round
 from archeryutils.targets import ScoringSystem
 
+
 class TestPass:
     """
     Class to test the Pass class.
@@ -113,6 +114,7 @@ class TestRound:
     def test_get_info()
         test get_info functionality of Round
     """
+
     def test_init_with_iterable_passes(self) -> None:
         """
         Check that Round can be intialised with a sequence/iterable of Passes.
@@ -156,7 +158,7 @@ class TestRound:
         self,
         unit: str,
         get_unit: bool,
-        max_dist_expected: Union[float, tuple[float,str]],
+        max_dist_expected: Union[float, tuple[float, str]],
     ) -> None:
         """
         Check that max distance is calculated correctly for a Round.

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -4,7 +4,7 @@ from typing import Union
 import pytest
 
 from archeryutils.rounds import Pass, Round
-
+from archeryutils.targets import ScoringSystem
 
 class TestPass:
     """
@@ -88,7 +88,7 @@ class TestPass:
     )
     def test_max_score(
         self,
-        face_type: str,
+        face_type: ScoringSystem,
         max_score_expected: float,
     ) -> None:
         """

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -1,6 +1,6 @@
 """Tests for Pass and Round classes"""
+from typing import Union
 
-from typing import Union, Tuple
 import pytest
 
 from archeryutils.rounds import Pass, Round
@@ -142,7 +142,7 @@ class TestRound:
         self,
         unit: str,
         get_unit: bool,
-        max_dist_expected: Union[float, Tuple[float, str]],
+        max_dist_expected: Union[float, tuple[float,str]],
     ) -> None:
         """
         Check that max distance is calculated correctly for a Round.

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -113,6 +113,20 @@ class TestRound:
     def test_get_info()
         test get_info functionality of Round
     """
+    def test_init_with_iterable_passes(self) -> None:
+        """
+        Check that Round can be intialised with a sequence/iterable of Passes.
+
+        Verify by eq comparison of attribute as Round.__eq__ not defined
+        """
+        pass_a = Pass(100, "5_zone", 122, 50, False)
+        pass_b = Pass(100, "5_zone", 122, 40, False)
+
+        list_ = Round("List", [pass_a, pass_b])
+        tuple_ = Round("Tuple", (pass_a, pass_b))
+        iterable_ = Round("iterable", (p for p in (pass_a, pass_b)))
+
+        assert list_.passes == tuple_.passes == iterable_.passes
 
     def test_max_score(self) -> None:
         """

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -1,4 +1,5 @@
 """Tests for Pass and Round classes"""
+
 from typing import Union
 
 import pytest

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -26,7 +26,7 @@ class TestTarget:
             match="Invalid Target Face Type specified.\nPlease select from '(.+)'.",
         ):
             # Silence mypy as scoring_system must be a valid literal ScoringSystem
-            Target("InvalidScoringSystem", 122, 50, False) #type: ignore[arg-type]
+            Target("InvalidScoringSystem", 122, 50, False)  # type: ignore[arg-type]
 
     def test_invalid_distance_unit(self) -> None:
         """
@@ -126,7 +126,9 @@ class TestTarget:
             ("Beiter_hit_miss", 1),
         ],
     )
-    def test_max_score(self, face_type: ScoringSystem, max_score_expected: float) -> None:
+    def test_max_score(
+        self, face_type: ScoringSystem, max_score_expected: float
+    ) -> None:
         """
         Check that Target() returns correct max score.
         """
@@ -144,7 +146,7 @@ class TestTarget:
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
             # Silence mypy as scoring_system must be a valid literal ScoringSystem
-            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
+            target.scoring_system = "InvalidScoringSystem"  # type: ignore[assignment]
             target.max_score()
 
     @pytest.mark.parametrize(
@@ -164,7 +166,9 @@ class TestTarget:
             ("Beiter_hit_miss", 0),
         ],
     )
-    def test_min_score(self, face_type: ScoringSystem, min_score_expected: float) -> None:
+    def test_min_score(
+        self, face_type: ScoringSystem, min_score_expected: float
+    ) -> None:
         """
         Check that Target() returns correct min score.
         """
@@ -182,5 +186,5 @@ class TestTarget:
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
             # Silence mypy as scoring_system must be a valid literal ScoringSystem
-            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
+            target.scoring_system = "InvalidScoringSystem"  # type: ignore[assignment]
             target.min_score()

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -25,6 +25,7 @@ class TestTarget:
             ValueError,
             match="Invalid Target Face Type specified.\nPlease select from '(.+)'.",
         ):
+            # Silence mypy as scoring_system must be a valid literal ScoringSystem
             Target("InvalidScoringSystem", 122, 50, False) #type: ignore[arg-type]
 
     def test_invalid_distance_unit(self) -> None:
@@ -142,6 +143,7 @@ class TestTarget:
         ):
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
+            # Silence mypy as scoring_system must be a valid literal ScoringSystem
             target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
             target.max_score()
 
@@ -179,5 +181,6 @@ class TestTarget:
         ):
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
+            # Silence mypy as scoring_system must be a valid literal ScoringSystem
             target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
             target.min_score()

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from archeryutils.targets import Target
+from archeryutils.targets import Target, ScoringSystem
 
 
 class TestTarget:
@@ -25,7 +25,7 @@ class TestTarget:
             ValueError,
             match="Invalid Target Face Type specified.\nPlease select from '(.+)'.",
         ):
-            Target("InvalidScoringSystem", 122, 50, False)
+            Target("InvalidScoringSystem", 122, 50, False) #type: ignore[arg-type]
 
     def test_invalid_distance_unit(self) -> None:
         """
@@ -125,7 +125,7 @@ class TestTarget:
             ("Beiter_hit_miss", 1),
         ],
     )
-    def test_max_score(self, face_type: str, max_score_expected: float) -> None:
+    def test_max_score(self, face_type: ScoringSystem, max_score_expected: float) -> None:
         """
         Check that Target() returns correct max score.
         """
@@ -142,7 +142,7 @@ class TestTarget:
         ):
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
-            target.scoring_system = "InvalidScoringSystem"
+            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
             target.max_score()
 
     @pytest.mark.parametrize(
@@ -162,7 +162,7 @@ class TestTarget:
             ("Beiter_hit_miss", 0),
         ],
     )
-    def test_min_score(self, face_type: str, min_score_expected: float) -> None:
+    def test_min_score(self, face_type: ScoringSystem, min_score_expected: float) -> None:
         """
         Check that Target() returns correct min score.
         """
@@ -179,5 +179,5 @@ class TestTarget:
         ):
             target = Target("5_zone", 122, 50, False)
             # Requires manual resetting of scoring system to get this error.
-            target.scoring_system = "InvalidScoringSystem"
+            target.scoring_system = "InvalidScoringSystem" #type: ignore[assignment]
             target.min_score()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,10 @@ exclude_patterns = [
 
 pygments_style = "sphinx"
 
+# This may not work without both
+# from __future__ import annotations
+# and explicit typing of alias types with typing.TypeAlias
+autodoc_type_aliases = {'ScoringSystem': 'targets.ScoringSystem'}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,11 +40,6 @@ exclude_patterns = [
 
 pygments_style = "sphinx"
 
-# This may not work without both
-# from __future__ import annotations
-# and explicit typing of alias types with typing.TypeAlias
-autodoc_type_aliases = {"ScoringSystem": "targets.ScoringSystem"}
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ pygments_style = "sphinx"
 # This may not work without both
 # from __future__ import annotations
 # and explicit typing of alias types with typing.TypeAlias
-autodoc_type_aliases = {'ScoringSystem': 'targets.ScoringSystem'}
+autodoc_type_aliases = {"ScoringSystem": "targets.ScoringSystem"}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -205,7 +205,7 @@
     "### Round\n",
     "In reality we rarely use the `targets.Target` or `rounds.Pass` objects by themselves, however, instead preferring to use the `rounds.Round` class. This defines multiple passes to form what is commonly known as a round.\n",
     "\n",
-    "A `rounds.Round` object is defined with a string `name` to provide a popular name for the round and an iterable of `rounds.Pass` objects, which will be stored as a list on the `passes` attribute.\n",
+    "A `rounds.Round` object is defined with a string `name` to provide a popular name for the round and an iterable of `rounds.Pass` objects, which will be stored as a list in the `passes` attribute.\n",
     "\n",
     "It may also take the following optional string arguments:\n",
     "- `location` - where the round is shot, e.g. 'Indoor', 'Outdoor', 'Field' etc.\n",

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -205,7 +205,7 @@
     "### Round\n",
     "In reality we rarely use the `targets.Target` or `rounds.Pass` objects by themselves, however, instead preferring to use the `rounds.Round` class. This defines multiple passes to form what is commonly known as a round.\n",
     "\n",
-    "A `rounds.Round` object is defined with a string `name` to provide a popular name for the round and a list of `rounds.Pass` objects.\n",
+    "A `rounds.Round` object is defined with a string `name` to provide a popular name for the round and an iterable of `rounds.Pass` objects, which will be stored as a list on the `passes` attribute.\n",
     "\n",
     "It may also take the following optional string arguments:\n",
     "- `location` - where the round is shot, e.g. 'Indoor', 'Outdoor', 'Field' etc.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ docs = [
     "sphinx-toolbox",
     "nbsphinx",
     "ipython",
+    "pickleshare",  # https://github.com/ipython/ipython/issues/14237
     "black>=24.1.0",
     "blackdoc",
 ]


### PR DESCRIPTION
Closes #61 

Should be compatible with python 3.9+ syntax. In order of increasing intensity:

- Replaced Dict, Tuple, List etc.
- Use type variable in handicap equations to show when floats or arrays are given as input and are returned as output
- type hints for fixed dictionaries for AGB classification data that are read from JSON
- enforce correct scoring systems for target class using literal types.

The sum of the last three points allow for removing some of the extra assertions that were in place just to please mypy, especially in the score_for_round functions.

There are still a couple of Anys floating around that I might be able to excise, but this feels like most of it, and enough that I could do with a check over to see if anything else needs included in this one.

On the topic of making the scoring systems explicitly typed, I did think about looking at handicap systems as well, either as a literal type or an Enum, but with potential refactors coming from #2 that seemed like a step too far.

Other general feedback from the process of working on this:
- Some of the JSON files being read in are extremely small and I question the value of having to read them in every time they are used vs just defining them in code, in particular the AGB Genders (which the functions to build the classification dictionaries assume the contents of anyway).
- Type hints in the test files were a bit of a pain in the backside and a few needed to be changed/ignored, which adds a bit more friction to development.