### PR TITLE
Class improvements - constructors and reprs

### DIFF
--- a/archeryutils/handicaps/tests/test_handicap_tables.py
+++ b/archeryutils/handicaps/tests/test_handicap_tables.py
@@ -19,24 +19,24 @@ hc_params = hc_eq.HcParams()
 york = Round(
     "York",
     [
-        Pass(72, "5_zone", 122, (100, "yard"), False),
-        Pass(48, "5_zone", 122, (80, "yard"), False),
-        Pass(24, "5_zone", 122, (60, "yard"), False),
+        Pass.at_target(72, "5_zone", 122, (100, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (80, "yard"), False),
+        Pass.at_target(24, "5_zone", 122, (60, "yard"), False),
     ],
 )
 hereford = Round(
     "Hereford",
     [
-        Pass(72, "5_zone", 122, (80, "yard"), False),
-        Pass(48, "5_zone", 122, (60, "yard"), False),
-        Pass(24, "5_zone", 122, (50, "yard"), False),
+        Pass.at_target(72, "5_zone", 122, (80, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (60, "yard"), False),
+        Pass.at_target(24, "5_zone", 122, (50, "yard"), False),
     ],
 )
 metric122_30 = Round(
     "Metric 122-30",
     [
-        Pass(36, "10_zone", 122, 30, False),
-        Pass(36, "10_zone", 122, 30, False),
+        Pass.at_target(36, "10_zone", 122, 30, False),
+        Pass.at_target(36, "10_zone", 122, 30, False),
     ],
 )
 

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -20,62 +20,62 @@ hc_params = hc_eq.HcParams()
 york = Round(
     "York",
     [
-        Pass(72, "5_zone", 122, (100, "yard"), False),
-        Pass(48, "5_zone", 122, (80, "yard"), False),
-        Pass(24, "5_zone", 122, (60, "yard"), False),
+        Pass.at_target(72, "5_zone", 122, (100, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (80, "yard"), False),
+        Pass.at_target(24, "5_zone", 122, (60, "yard"), False),
     ],
 )
 hereford = Round(
     "Hereford",
     [
-        Pass(72, "5_zone", 122, (80, "yard"), False),
-        Pass(48, "5_zone", 122, (60, "yard"), False),
-        Pass(24, "5_zone", 122, (50, "yard"), False),
+        Pass.at_target(72, "5_zone", 122, (80, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (60, "yard"), False),
+        Pass.at_target(24, "5_zone", 122, (50, "yard"), False),
     ],
 )
 western = Round(
     "Western",
     [
-        Pass(48, "5_zone", 122, (60, "yard"), False),
-        Pass(48, "5_zone", 122, (50, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (60, "yard"), False),
+        Pass.at_target(48, "5_zone", 122, (50, "yard"), False),
     ],
 )
 vegas300 = Round(
     "Vegas 300",
     [
-        Pass(30, "10_zone", 40, (20, "yard"), True),
+        Pass.at_target(30, "10_zone", 40, (20, "yard"), True),
     ],
 )
 wa1440_90 = Round(
     "WA1440 90m",
     [
-        Pass(36, "10_zone", 122, (90, "metre"), False),
-        Pass(36, "10_zone", 122, (70, "metre"), False),
-        Pass(36, "10_zone", 80, (50, "metre"), False),
-        Pass(36, "10_zone", 80, (30, "metre"), False),
+        Pass.at_target(36, "10_zone", 122, (90, "metre"), False),
+        Pass.at_target(36, "10_zone", 122, (70, "metre"), False),
+        Pass.at_target(36, "10_zone", 80, (50, "metre"), False),
+        Pass.at_target(36, "10_zone", 80, (30, "metre"), False),
     ],
 )
 wa1440_70 = Round(
     "WA1440 70m",
     [
-        Pass(36, "10_zone", 122, 70, False),
-        Pass(36, "10_zone", 122, 60, False),
-        Pass(36, "10_zone", 80, 50, False),
-        Pass(36, "10_zone", 80, 30, False),
+        Pass.at_target(36, "10_zone", 122, 70, False),
+        Pass.at_target(36, "10_zone", 122, 60, False),
+        Pass.at_target(36, "10_zone", 80, 50, False),
+        Pass.at_target(36, "10_zone", 80, 30, False),
     ],
 )
 wa720_70 = Round(
     "WA 720 70m",
     [
-        Pass(36, "10_zone", 122, 70, False),
-        Pass(36, "10_zone", 122, 70, False),
+        Pass.at_target(36, "10_zone", 122, 70, False),
+        Pass.at_target(36, "10_zone", 122, 70, False),
     ],
 )
 metric122_30 = Round(
     "Metric 122-30",
     [
-        Pass(36, "10_zone", 122, 30, False),
-        Pass(36, "10_zone", 122, 30, False),
+        Pass.at_target(36, "10_zone", 122, 30, False),
+        Pass.at_target(36, "10_zone", 122, 30, False),
     ],
 )
 
@@ -491,9 +491,9 @@ class TestScoreForRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, "10_zone", 122, 100, False),
-                Pass(10, "10_zone", 80, 80, False),
-                Pass(10, "5_zone", 122, 60, False),
+                Pass.at_target(10, "10_zone", 122, 100, False),
+                Pass.at_target(10, "10_zone", 80, 80, False),
+                Pass.at_target(10, "5_zone", 122, 60, False),
             ],
         )
 
@@ -526,9 +526,9 @@ class TestScoreForRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, "10_zone", 122, 100, False),
-                Pass(10, "10_zone", 80, 80, False),
-                Pass(10, "5_zone", 122, 60, False),
+                Pass.at_target(10, "10_zone", 122, 100, False),
+                Pass.at_target(10, "10_zone", 80, 80, False),
+                Pass.at_target(10, "5_zone", 122, 60, False),
             ],
         )
 
@@ -625,8 +625,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, "10_zone", 122, 50, False),
-                    Pass(10, "10_zone", 80, 50, False),
+                    Pass.at_target(10, "10_zone", 122, 50, False),
+                    Pass.at_target(10, "10_zone", 80, 50, False),
                 ],
             )
 
@@ -646,8 +646,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, "10_zone", 122, 50, False),
-                    Pass(10, "10_zone", 80, 50, False),
+                    Pass.at_target(10, "10_zone", 122, 50, False),
+                    Pass.at_target(10, "10_zone", 80, 50, False),
                 ],
             )
 
@@ -667,8 +667,8 @@ class TestHandicapFromScore:
             test_round = Round(
                 "TestRound",
                 [
-                    Pass(10, "10_zone", 122, 50, False),
-                    Pass(10, "10_zone", 80, 50, False),
+                    Pass.at_target(10, "10_zone", 122, 50, False),
+                    Pass.at_target(10, "10_zone", 80, 50, False),
                 ],
             )
 

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -109,7 +109,7 @@ def read_json_to_round_dict(json_filelist: Union[str, list[str]]) -> dict[str, R
                 if "diameter_unit" not in pass_i.keys():
                     pass_i["diameter_unit"] = "cm"
             passes = [
-                Pass(
+                Pass.at_target(
                     pass_i["n_arrows"],
                     pass_i["scoring"],
                     (pass_i["diameter"], pass_i["diameter_unit"]),
@@ -199,5 +199,6 @@ IFAA_field = _make_rounds_dict("IFAA_field.json")
 WA_VI = _make_rounds_dict("WA_VI.json")
 AGB_VI = _make_rounds_dict("AGB_VI.json")
 custom = _make_rounds_dict("Custom.json")
+
 
 del _make_rounds_dict

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -7,6 +7,41 @@ from typing import Union, Any
 
 from archeryutils.rounds import Pass, Round
 
+LOCATIONS = {
+    "indoor": {
+        "i",
+        "I",
+        "indoors",
+        "indoor",
+        "in",
+        "inside",
+        "Indoors",
+        "Indoor",
+        "In",
+        "Inside",
+    },
+    "outdoor": {
+        "o",
+        "O",
+        "outdoors",
+        "outdoor",
+        "out",
+        "outside",
+        "Outdoors",
+        "Outdoor",
+        "Out",
+        "Outside",
+    },
+    "field": {
+        "f",
+        "F",
+        "field",
+        "Field",
+        "woods",
+        "Woods",
+    },
+}
+
 
 def read_json_to_round_dict(json_filelist: Union[str, list[str]]) -> dict[str, Round]:
     """
@@ -42,44 +77,19 @@ def read_json_to_round_dict(json_filelist: Union[str, list[str]]) -> dict[str, R
                 )
                 round_i["location"] = None
                 round_i["indoor"] = False
-            elif round_i["location"] in (
-                "i",
-                "I",
-                "indoors",
-                "indoor",
-                "in",
-                "inside",
-                "Indoors",
-                "Indoor",
-                "In",
-                "Inside",
-            ):
+
+            elif round_i["location"] in LOCATIONS["indoor"]:
                 round_i["indoor"] = True
                 round_i["location"] = "indoor"
-            elif round_i["location"] in (
-                "o",
-                "O",
-                "outdoors",
-                "outdoor",
-                "out",
-                "outside",
-                "Outdoors",
-                "Outdoor",
-                "Out",
-                "Outside",
-            ):
+
+            elif round_i["location"] in LOCATIONS["outdoor"]:
                 round_i["indoor"] = False
                 round_i["location"] = "outdoor"
-            elif round_i["location"] in (
-                "f",
-                "F",
-                "field",
-                "Field",
-                "woods",
-                "Woods",
-            ):
+
+            elif round_i["location"] in LOCATIONS["field"]:
                 round_i["indoor"] = False
                 round_i["location"] = "field"
+
             else:
                 warnings.warn(
                     f"Location not recognised for round {round_i['name']}. "
@@ -105,14 +115,11 @@ def read_json_to_round_dict(json_filelist: Union[str, list[str]]) -> dict[str, R
                 round_i["family"] = ""
 
             # Assign passes
-            for pass_i in round_i["passes"]:
-                if "diameter_unit" not in pass_i.keys():
-                    pass_i["diameter_unit"] = "cm"
             passes = [
                 Pass.at_target(
                     pass_i["n_arrows"],
                     pass_i["scoring"],
-                    (pass_i["diameter"], pass_i["diameter_unit"]),
+                    (pass_i["diameter"], pass_i.get("diameter_unit", "cm")),
                     (pass_i["distance"], pass_i["dist_unit"]),
                     indoor=round_i["indoor"],
                 )

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -19,24 +19,15 @@ class Pass:
     ----------
     n_arrows : int
         number of arrows in this pass.
-    scoring_system : {\
-        ``"5_zone"`` ``"10_zone"`` ``"10_zone_compound"`` ``"10_zone_6_ring"``\
-        ``"10_zone_5_ring"`` ``"10_zone_5_ring_compound"`` ``"WA_field"`` ``"IFAA_field"``\
-        ``"IFAA_field_expert"`` ``"Beiter_hit_miss"`` ``"Worcester"`` ``"Worcester_2_ring"``}
-        target face/scoring system type. Must be one of the supported values.
-    diameter : float or tuple of float, str
-        face diameter in [centimetres].
-    distance : float or tuple of float, str
-        linear distance from archer to target in [metres].
-    indoor : bool, default=False
-        is round indoors for arrow diameter purposes?
+    target : Target
+        A Target object.
 
     Attributes
     ----------
     n_arrows : int
         number of arrows in this pass.
     target : Target
-        A Target object defined using input parameters.
+        A Target object.
 
     Examples
     --------
@@ -54,19 +45,58 @@ class Pass:
     archeryutils.Target : The `Target` class.
     """
 
-    # One too many arguments, but logically this structure makes sense => disable
-    # pylint: disable=too-many-arguments
+    def __init__(self, n_arrows: int, target: Target) -> None:
+        self.n_arrows = abs(n_arrows)
+        self.target = target
 
-    def __init__(
-        self,
+    # One too many arguments, but required to match Target signature => disable
+    # pylint: disable=too-many-arguments
+    @classmethod
+    def at_target(
+        cls,
         n_arrows: int,
         scoring_system: ScoringSystem,
         diameter: Union[float, tuple[float, str]],
         distance: Union[float, tuple[float, str]],
         indoor: bool = False,
-    ) -> None:
-        self.n_arrows = abs(n_arrows)
-        self.target = Target(scoring_system, diameter, distance, indoor)
+    ) -> "Pass":
+        """
+        Initalise a Pass directly with the parameters of its target.
+
+        The parameters are passed directly to the default Target constuctor and
+        therefore share the same behaviours and defaults.
+
+        Parameters
+        ----------
+        n_arrows : int
+            number of arrows in this pass
+        scoring_system : {\
+        ``"5_zone"`` ``"10_zone"`` ``"10_zone_compound"`` ``"10_zone_6_ring"``\
+        ``"10_zone_5_ring"`` ``"10_zone_5_ring_compound"`` ``"WA_field"`` ``"IFAA_field"``\
+        ``"IFAA_field_expert"`` ``"Beiter_hit_miss"`` ``"Worcester"`` ``"Worcester_2_ring"``}
+            target face/scoring system type
+        diameter : float
+            face diameter in [centimetres]
+        distance : float
+            linear distance from archer to target in [metres]
+        dist_unit : str
+            The unit distance is measured in. default = 'metres'
+        indoor : bool
+            is round indoors for arrow diameter purposes? default = False
+        diameter_unit : str
+            The unit face diameter is measured in. default = 'centimetres'
+
+        Returns
+        -------
+        Pass
+            The constructed Pass instance
+
+        Examples
+        --------
+        >>> pass_ = au.Pass.at_target(36, "10_zone", 122, 70.0)
+        """
+        target = Target(scoring_system, diameter, distance, indoor)
+        return cls(n_arrows, target)
 
     def __repr__(self) -> str:
         """Return a representation of a Pass instance."""

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -68,6 +68,10 @@ class Pass:
         self.n_arrows = abs(n_arrows)
         self.target = Target(scoring_system, diameter, distance, indoor)
 
+    def __repr__(self) -> str:
+        """Return a representation of a Pass instance."""
+        return f"Pass({self.n_arrows}, {self.target})"
+
     @property
     def scoring_system(self) -> ScoringSystem:
         """Get target scoring_system."""
@@ -176,6 +180,10 @@ class Round:
         self.location = location
         self.body = body
         self.family = family
+
+    def __repr__(self) -> str:
+        """Return a representation of a Round instance."""
+        return f"Round('{self.name}')"
 
     def max_score(self) -> float:
         """

--- a/archeryutils/targets.py
+++ b/archeryutils/targets.py
@@ -127,6 +127,21 @@ class Target:
         self.native_dist_unit = Length.definitive_unit(native_dist_unit)
         self.indoor = indoor
 
+    def __repr__(self) -> str:
+        """Return a representation of a Target instance.
+
+        Displays diameter and distance as stored in metres to avoid peforming extra
+        logic for display, however units are shown to allow reconstruction.
+        """
+        return (
+            "Target("
+            f"'{self.scoring_system}', "
+            f"({self.diameter:.6g}, 'metre'), "  # si units, avoid reconversion
+            f"({self.distance:.6g}, 'metre'), "  # si units, avoid reconversion
+            f"indoor={self.indoor}"
+            ")"
+        )
+
     def max_score(self) -> float:
         """
         Return the maximum numerical score possible on this target (i.e. not X).

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -4,8 +4,11 @@ from typing import Union
 
 import pytest
 
-from archeryutils.rounds import Pass, Round
+from archeryutils.rounds import Pass, Round, Target
 from archeryutils.targets import ScoringSystem
+
+
+_target = Target("5_zone", 122, 50)
 
 
 class TestPass:
@@ -26,11 +29,30 @@ class TestPass:
         test max score functionality of Pass
     """
 
+    def test_init(self) -> None:
+        """
+        Check direct initialisation of a Pass with a target instance.
+        """
+        test_pass = Pass(36, _target)
+
+        assert test_pass.target == _target
+        assert test_pass.n_arrows == 36
+
+    def test_at_target_constructor(self) -> None:
+        """
+        Check indirect initialisation of a Pass with target parameters.
+        """
+        test_pass = Pass.at_target(36, "5_zone", 122, 50)
+
+        assert test_pass.n_arrows == 36
+        # cannot test for equality between targets as __eq__ not implemented
+        # assert test_pass.target == _target
+
     def test_repr(self) -> None:
         """
-        Check Pass string representation
+        Check Pass string representation.
         """
-        test_pass = Pass(36, "5_zone", 122, 50)
+        test_pass = Pass(36, _target)
         expected = (
             "Pass(36, Target('5_zone', (1.22, 'metre'), (50, 'metre'), indoor=False))"
         )
@@ -38,16 +60,16 @@ class TestPass:
 
     def test_default_distance_unit(self) -> None:
         """
-        Check that Pass() returns distance in metres when units not specified.
+        Check that Pass returns distance in metres when units not specified.
         """
-        test_pass = Pass(36, "5_zone", 122, 50)
+        test_pass = Pass.at_target(36, "5_zone", 122, 50)
         assert test_pass.native_dist_unit == "metre"
 
     def test_default_diameter_unit(self) -> None:
         """
-        Check that Pass() has same default diameter units as Target.
+        Check that Pass has same default diameter units as Target.
         """
-        test_pass = Pass(36, "5_zone", 122, 50)
+        test_pass = Pass.at_target(36, "5_zone", 122, 50)
         assert (
             test_pass.native_diameter_unit
             == test_pass.target.native_diameter_unit
@@ -56,30 +78,30 @@ class TestPass:
 
     def test_diameter_units_passed_to_target(self) -> None:
         """
-        Check that Pass() passes on diameter units to Target object.
+        Check that Pass passes on diameter units to Target object.
         """
-        test_pass = Pass(60, "Worcester", (16, "inches"), (20, "yards"))
+        test_pass = Pass.at_target(60, "Worcester", (16, "inches"), (20, "yards"))
         assert test_pass.target.native_diameter_unit == "inch"
 
     def test_default_location(self) -> None:
         """
-        Check that Pass() returns indoor=False when indoor not specified.
+        Check that Pass returns indoor=False when indoor not specified.
         """
-        test_pass = Pass(36, "5_zone", 122, 50)
+        test_pass = Pass.at_target(36, "5_zone", 122, 50)
         assert test_pass.indoor is False
 
     def test_negative_arrows(self) -> None:
         """
         Check that Pass() uses abs(narrows).
         """
-        test_pass = Pass(-36, "5_zone", 122, 50)
+        test_pass = Pass(-36, _target)
         assert test_pass.n_arrows == 36
 
     def test_properties(self) -> None:
         """
         Check that Pass properties are set correctly
         """
-        test_pass = Pass(36, "5_zone", (122, "cm"), (50, "metre"), False)
+        test_pass = Pass(36, Target("5_zone", (122, "cm"), (50, "metre"), False))
         assert test_pass.distance == 50.0
         assert test_pass.native_dist_unit == "metre"
         assert test_pass.diameter == 1.22
@@ -106,7 +128,7 @@ class TestPass:
         """
         Check that Pass.max_score() method is functioning correctly
         """
-        test_pass = Pass(100, face_type, 122, 50, False)
+        test_pass = Pass.at_target(100, face_type, 122, 50, False)
         assert test_pass.max_score() == max_score_expected
 
 
@@ -132,8 +154,8 @@ class TestRound:
 
         Verify by eq comparison of attribute as Round.__eq__ not defined
         """
-        pass_a = Pass(100, "5_zone", 122, 50, False)
-        pass_b = Pass(100, "5_zone", 122, 40, False)
+        pass_a = Pass.at_target(100, "5_zone", 122, 50, False)
+        pass_b = Pass.at_target(100, "5_zone", 122, 40, False)
 
         list_ = Round("List", [pass_a, pass_b])
         tuple_ = Round("Tuple", (pass_a, pass_b))
@@ -145,7 +167,7 @@ class TestRound:
         """
         Check Pass string representation
         """
-        test_round = Round("Name", [Pass(36, "5_zone", 122, 50)])
+        test_round = Round("Name", [Pass(36, _target)])
         expected = "Round('Name')"
         assert repr(test_round) == expected
 
@@ -157,9 +179,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(100, "5_zone", 122, 50, False),
-                Pass(100, "5_zone", 122, 40, False),
-                Pass(100, "5_zone", 122, 30, False),
+                Pass.at_target(100, "5_zone", 122, 50, False),
+                Pass.at_target(100, "5_zone", 122, 40, False),
+                Pass.at_target(100, "5_zone", 122, 30, False),
             ],
         )
         assert test_round.max_score() == 2700
@@ -190,9 +212,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, "5_zone", 122, (100, unit), False),
-                Pass(10, "5_zone", 122, (80, unit), False),
-                Pass(10, "5_zone", 122, (60, unit), False),
+                Pass.at_target(10, "5_zone", 122, (100, unit), False),
+                Pass.at_target(10, "5_zone", 122, (80, unit), False),
+                Pass.at_target(10, "5_zone", 122, (60, unit), False),
             ],
         )
         assert test_round.max_distance(unit=get_unit) == max_dist_expected
@@ -205,9 +227,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, "5_zone", 122, 80, False),
-                Pass(10, "5_zone", 122, 100, False),
-                Pass(10, "5_zone", 122, 60, False),
+                Pass.at_target(10, "5_zone", 122, 80, False),
+                Pass.at_target(10, "5_zone", 122, 100, False),
+                Pass.at_target(10, "5_zone", 122, 60, False),
             ],
         )
         assert test_round.max_distance() == 100
@@ -216,8 +238,8 @@ class TestRound:
         """
         Check that max distance accounts for different units in round
         """
-        pyards = Pass(36, "5_zone", 122, (80, "yard"))
-        pmetric = Pass(36, "5_zone", 122, (75, "metres"))
+        pyards = Pass.at_target(36, "5_zone", 122, (80, "yard"))
+        pmetric = Pass.at_target(36, "5_zone", 122, (75, "metres"))
         test_round = Round("test", [pyards, pmetric])
 
         assert pmetric.distance > pyards.distance
@@ -230,9 +252,9 @@ class TestRound:
         test_round = Round(
             "MyRound",
             [
-                Pass(10, "5_zone", 122, 100, False),
-                Pass(20, "5_zone", 122, (80, "yards"), False),
-                Pass(30, "5_zone", 80, (60, "metre"), False),
+                Pass.at_target(10, "5_zone", 122, 100, False),
+                Pass.at_target(20, "5_zone", 122, (80, "yards"), False),
+                Pass.at_target(30, "5_zone", 80, (60, "metre"), False),
             ],
         )
         test_round.get_info()

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -26,6 +26,16 @@ class TestPass:
         test max score functionality of Pass
     """
 
+    def test_repr(self) -> None:
+        """
+        Check Pass string representation
+        """
+        test_pass = Pass(36, "5_zone", 122, 50)
+        expected = (
+            "Pass(36, Target('5_zone', (1.22, 'metre'), (50, 'metre'), indoor=False))"
+        )
+        assert repr(test_pass) == expected
+
     def test_default_distance_unit(self) -> None:
         """
         Check that Pass() returns distance in metres when units not specified.
@@ -130,6 +140,14 @@ class TestRound:
         iterable_ = Round("iterable", (p for p in (pass_a, pass_b)))
 
         assert list_.passes == tuple_.passes == iterable_.passes
+
+    def test_repr(self) -> None:
+        """
+        Check Pass string representation
+        """
+        test_round = Round("Name", [Pass(36, "5_zone", 122, 50)])
+        expected = "Round('Name')"
+        assert repr(test_round) == expected
 
     def test_max_score(self) -> None:
         """

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -17,6 +17,24 @@ class TestTarget:
         test if invalid distance unit raises an error
     """
 
+    def test_repr(self) -> None:
+        """
+        Check Target string representation is as expected.
+        """
+        target = Target("10_zone", 80, 30)
+        expected = "Target('10_zone', (0.8, 'metre'), (30, 'metre'), indoor=False)"
+        assert repr(target) == expected
+
+    def test_repr_formatting(self) -> None:
+        """
+        Check Target string representation rounds/truncates where needed.
+        """
+        target = Target("Worcester", (16, "inches"), (20, "yards"), indoor=True)
+        expected = (
+            "Target('Worcester', (0.4064, 'metre'), (18.288, 'metre'), indoor=True)"
+        )
+        assert repr(target) == expected
+
     def test_invalid_system(self) -> None:
         """
         Check that Target() returns error value for invalid system.

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -78,8 +78,14 @@ a target:
 
 .. ipython:: python
 
-    my70mPass = au.Pass(36, "10_zone", 122, 70.0)
+    my70mPass = au.Pass(36, my720target)
     print(my70mPass.max_score())
+
+We can also directly construct a Pass and Target at the same time using the `at_target` constructor
+
+.. ipython:: python
+
+    my70mPass = au.Pass.at_target(36, "10_zone", 122, 70.0)
 
 Round
 -----

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -174,7 +174,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my70mPass = au.Pass(36, \"10_zone\", 122, 70.0)"
+    "my70mPass = au.Pass(36, my720target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15415889",
+   "metadata": {},
+   "source": [
+    "We can also directly construct a Pass and Target at the same time using the `at_target` constructor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8035f27c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my70mPass = au.Pass.at_target(36, \"10_zone\", 122, 70.0)"
    ]
   },
   {


### PR DESCRIPTION
Fairly small patch this one but closes #70 and improves the QOL of working with the classes a little.
- Add reprs to Target, Pass and Round
- Change Round constructor to directly accept a Target instance.
   - Add an `at_target` classmethod to replicate the previous functionality of passing parameters through to create a target
   - Implementation is exactly the same as previous init function
- Updated documentation and examples notebook

Optional change as its slightly out of scope, had to touch the load_rounds module to adapt to new constructors, while I was there cleaned up the read_json function a little by:
- factoring out the various string aliases for locations
- swapping manual dict iteration for missing diameter units for a get call with default value "cm"