### PR TITLE
Test speed

### DIFF
--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -589,11 +589,15 @@ class HandicapScheme(ABC):
             handicap = max(self.scale_bounds)
             delta_hc = -0.01
 
-        s_max = self.score_for_round(handicap, rnd, arw_d, rounded_score=False)
+        target = max_score - self.max_score_rounding_lim
+
+        def check_score(handicap):
+            return self.score_for_round(handicap, rnd, arw_d, rounded_score=False)
+
         # Work down to where we would round or ceil to max score
-        while s_max > max_score - self.max_score_rounding_lim:
+        while check_score(handicap) > target:
             handicap = handicap + delta_hc
-            s_max = self.score_for_round(handicap, rnd, arw_d, rounded_score=False)
+
         handicap = handicap - delta_hc  # Undo final iteration that overshoots
         if int_prec:
             if self.desc_scale:


### PR DESCRIPTION
Fix for #75

- Changes algorithm in `get_max_score_handicap` to take coarse and then fine steps.
- Refactors code for readability and less local variables
- ~Also fix missing default None parameter for arrow diameter~
    - this was implemented already duriung #78 
    - Only site that calls this function (`handicap_from_score`) and the main function that this calls (`score_for_round`) both have default None on the arrow diameter parameter so it hasn't mattered but fixed for consistency with those functions when debugging/calling it directly