### PR TITLE
Use pydantic for HandicapScheme

### DIFF
--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -33,17 +33,18 @@ References
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import Optional, TypeVar, Union, overload
+from typing import Optional, Sequence, TypeVar, Union, overload
 
 import numpy as np
 import numpy.typing as npt
+from pydantic import BaseModel
 
 from archeryutils import rounds, targets
 
 FloatArray = TypeVar("FloatArray", float, npt.NDArray[np.float_])
 
 
-class HandicapScheme(ABC):
+class HandicapScheme(BaseModel, ABC):
     """
     Abstract Base Class to represent a generic handicap scheme.
 
@@ -57,11 +58,13 @@ class HandicapScheme(ABC):
         diameter of an indoor arrow [metres] for this scheme, default 9.3e-3
     desc_scale: bool
         does the scheme work on a descending scale i.e. lower handicap is better, default True
-    scale_bounds: list[int]
+    scale_bounds: Sequence[int]
         Reasonable upper and lower bounds on the handicap scale for bounding searches
     max_score_rounding_lim: float
         Limit to round the max score to when searching
         depends on scheme rounding method e.g. round() vs. ceil() etc.
+    scale_bounds: list[int]
+        Reasonable upper and lower bounds on the handicap scale for bounding searches
 
     Methods
     -------
@@ -80,19 +83,16 @@ class HandicapScheme(ABC):
 
     """
 
-    def __init__(self) -> None:
-        self.name: str = "unnamed"
+    name: str
 
-        # Set arrow diameters
-        # Some schemes will need to override these with other values
-        self.arw_d_out: float = 5.5e-3
-        self.arw_d_in: float = 9.3e-3
+    # Indoor and outdoor arrow diameters
+    arw_d_out: float
+    arw_d_in: float
 
-        # Scale parameters - defaults set a la AGB
-        # Some schemes will need to override
-        self.desc_scale: bool = True
-        self.scale_bounds: list[float] = [-75, 300]
-        self.max_score_rounding_lim: float = 1.0
+    # Handicap scheme and scale parameters
+    desc_scale: bool
+    scale_bounds: Sequence[float]
+    max_score_rounding_lim: float
 
     def __repr__(self) -> str:
         """Return a representation of a HandicapScheme instance."""

--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -63,8 +63,6 @@ class HandicapScheme(BaseModel, ABC):
     max_score_rounding_lim: float
         Limit to round the max score to when searching
         depends on scheme rounding method e.g. round() vs. ceil() etc.
-    scale_bounds: list[int]
-        Reasonable upper and lower bounds on the handicap scale for bounding searches
 
     Methods
     -------

--- a/archeryutils/handicaps/handicap_scheme_aa.py
+++ b/archeryutils/handicaps/handicap_scheme_aa.py
@@ -21,6 +21,8 @@ References
 
 """
 
+from typing import Sequence
+
 import numpy as np
 
 from .handicap_scheme import FloatArray, HandicapScheme
@@ -77,28 +79,22 @@ class HandicapAA(HandicapScheme):
 
     """
 
-    def __init__(
-        self,
-        ang_0: float = 1.0e-3,
-        k0: float = 2.37,
-        ks: float = 0.027,
-        kd: float = 0.004,
-    ):
-        super().__init__()
+    name: str = "AA"
 
-        self.params = {
-            "ang_0": ang_0,  # Baseline angle used for group size 1.0 [millirad].
-            "k0": k0,  # Offset required to set handicap 100 at desired score.
-            "ks": ks,  # Change with each step of geometric progression.
-            "kd": kd,  # Distance scaling factor [1/metres].
-        }
+    # Set arrow diameters
+    arw_d_out: float = 5.0e-3
+    arw_d_in: float = 9.3e-3
 
-        self.arw_d_out = 5.0e-3
+    # Scale parameters
+    desc_scale: bool = False
+    scale_bounds: Sequence[float] = [-250, 175]
+    max_score_rounding_lim: float = 0.5
 
-        self.name = "AA"
-        self.desc_scale = False
-        self.scale_bounds = [-250, 175]
-        self.max_score_rounding_lim: float = 0.5
+    # Handicap scheme equation specific parameters
+    ang_0: float = 1.0e-3  # Baseline angle used for group size 1.0 [millirad].
+    k0: float = 2.37  # Offset required to set handicap 100
+    ks: float = 0.027  # Change with each step of geometric
+    kd: float = 0.004  # Distance scaling factor [1/metres].
 
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
@@ -152,11 +148,11 @@ class HandicapAA(HandicapScheme):
         # convert to rad
         return (
             np.sqrt(2.0)
-            * self.params["ang_0"]
+            * self.ang_0
             * np.exp(
-                self.params["k0"]
-                - self.params["ks"] * handicap
-                + self.params["kd"] * dist
+                self.k0
+                - self.ks * handicap
+                + self.kd * dist
             )
         )
 
@@ -216,35 +212,24 @@ class HandicapAA2(HandicapScheme):
 
     """
 
-    def __init__(
-        self,
-        ang_0: float = 1.0e-3,
-        k0: float = 2.57,
-        ks: float = 0.027,
-        f1: float = 0.815,
-        f2: float = 0.185,
-        d0: float = 50.0,
-    ):
-        # two too many arguments, but all are hc-scheme params => disable
-        # pylint: disable=too-many-arguments
+    name: str = "AA2"
 
-        super().__init__()
+    # Set arrow diameters
+    arw_d_out: float = 5.0e-3
+    arw_d_in: float = 9.3e-3
 
-        self.params = {
-            "ang_0": ang_0,
-            "k0": k0,  # Offset required to set handicap 100 at desired score.
-            "ks": ks,  # Change with each step of geometric progression.
-            "f1": f1,  # 'Linear' scaling factor.
-            "f2": f2,  # 'Quadratic' scaling factor.
-            "d0": d0,  # Normalisation distance [metres].
-        }
+    # Scale parameters
+    desc_scale: bool = False
+    scale_bounds: Sequence[float] = [-250, 175]
+    max_score_rounding_lim: float = 0.5
 
-        self.arw_d_out = 5.0e-3
-
-        self.name = "AA2"
-        self.desc_scale = False
-        self.scale_bounds = [-250, 175]
-        self.max_score_rounding_lim: float = 0.5
+    # Handicap scheme equation specific parameters
+    ang_0: float = 1.0e-3  # Baseline angle used for group size 1.0 [millirad].
+    k0: float = 2.57  # Offset required to set handicap 100 at desired score.
+    ks: float = 0.027  # Change with each step of geometric
+    f1: float = 0.815  # 'Linear' scaling factor.
+    f2: float = 0.185  # 'Quadratic' scaling factor.
+    d0: float = 50.0  # Normalisation distance [metres].
 
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
@@ -298,7 +283,7 @@ class HandicapAA2(HandicapScheme):
         # convert to rad
         return (
             np.sqrt(2.0)
-            * self.params["ang_0"]
-            * np.exp(self.params["k0"] - self.params["ks"] * handicap)
-            * (self.params["f1"] + self.params["f2"] * dist / self.params["d0"])
+            * self.ang_0
+            * np.exp(self.k0 - self.ks * handicap)
+            * (self.f1 + self.f2 * dist / self.d0)
         )

--- a/archeryutils/handicaps/handicap_scheme_aa.py
+++ b/archeryutils/handicaps/handicap_scheme_aa.py
@@ -149,11 +149,7 @@ class HandicapAA(HandicapScheme):
         return (
             np.sqrt(2.0)
             * self.ang_0
-            * np.exp(
-                self.k0
-                - self.ks * handicap
-                + self.kd * dist
-            )
+            * np.exp(self.k0 - self.ks * handicap + self.kd * dist)
         )
 
 

--- a/archeryutils/handicaps/handicap_scheme_agb.py
+++ b/archeryutils/handicaps/handicap_scheme_agb.py
@@ -99,7 +99,6 @@ class HandicapAGB(HandicapScheme):
     ang_0: float = 5.0e-4
     kd: float = 0.00365
 
-
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
 
@@ -216,10 +215,10 @@ class HandicapAGBold(HandicapScheme):
     datum: float = 12.9  # Offset required to set handicap 0 at desired score.
     step: float = 3.6  # Percentage change in group size for each handicap step.
     ang_0: float = 5.0e-4  # Baseline angle used for group size 0.5 [millirad].
-    k1: float = 1.429e-6   # Constant 1 used in handicap equation.
-    k2: float = 1.07       # Constant 2 used in handicap equation.
-    k3: float = 4.3        # Constant 3 used in handicap equation.
-    p1: float = 2.0        # Exponent of distance scaling.
+    k1: float = 1.429e-6  # Constant 1 used in handicap equation.
+    k2: float = 1.07  # Constant 2 used in handicap equation.
+    k3: float = 4.3  # Constant 3 used in handicap equation.
+    p1: float = 2.0  # Exponent of distance scaling.
 
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
@@ -263,10 +262,8 @@ class HandicapAGBold(HandicapScheme):
         array([0.00112649, 0.00478762, 0.05520862])
 
         """
-        k_factor = self.k1 * self.k2 ** (
-            handicap + self.k3
-        )
-        f_factor = 1.0 + k_factor * dist ** self.p1
+        k_factor = self.k1 * self.k2 ** (handicap + self.k3)
+        f_factor = 1.0 + k_factor * dist**self.p1
         return (
             self.ang_0
             * ((1.0 + self.step / 100.0) ** (handicap + self.datum))

--- a/archeryutils/handicaps/handicap_scheme_agb.py
+++ b/archeryutils/handicaps/handicap_scheme_agb.py
@@ -22,6 +22,8 @@ References
 
 """
 
+from typing import Sequence
+
 import numpy as np
 
 from .handicap_scheme import FloatArray, HandicapScheme
@@ -80,23 +82,23 @@ class HandicapAGB(HandicapScheme):
 
     """
 
-    def __init__(
-        self,
-        datum: float = 6.0,
-        step: float = 3.5,
-        ang_0: float = 5.0e-4,
-        kd: float = 0.00365,
-    ):
-        super().__init__()
+    name: str = "AGB"
 
-        self.params = {
-            "datum": datum,
-            "step": step,
-            "ang_0": ang_0,
-            "kd": kd,
-        }
+    # Set arrow diameters
+    arw_d_out: float = 5.5e-3
+    arw_d_in: float = 9.3e-3
 
-        self.name = "AGB"
+    # Scale parameters
+    desc_scale: bool = True
+    scale_bounds: Sequence[float] = [-75, 300]
+    max_score_rounding_lim: float = 1.0
+
+    # Handicap scheme equation specific parameters
+    datum: float = 6.0
+    step: float = 3.5
+    ang_0: float = 5.0e-4
+    kd: float = 0.00365
+
 
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
@@ -131,9 +133,9 @@ class HandicapAGB(HandicapScheme):
 
         """
         return (
-            self.params["ang_0"]
-            * ((1.0 + self.params["step"] / 100.0) ** (handicap + self.params["datum"]))
-            * np.exp(self.params["kd"] * dist)
+            self.ang_0
+            * ((1.0 + self.step / 100.0) ** (handicap + self.datum))
+            * np.exp(self.kd * dist)
         )
 
     # Override rounding method for AGB to always round up to next highest score.
@@ -199,36 +201,25 @@ class HandicapAGBold(HandicapScheme):
 
     """
 
-    def __init__(
-        self,
-        datum: float = 12.9,
-        step: float = 3.6,
-        ang_0: float = 5.0e-4,
-        k1: float = 1.429e-6,
-        k2: float = 1.07,
-        k3: float = 4.3,
-        p1: float = 2.0,
-    ):
-        # three too many arguments, but all are hc-scheme params => disable
-        # pylint: disable=too-many-arguments
+    name: str = "AGBold"
 
-        super().__init__()
+    # Set arrow diameters
+    arw_d_out: float = 7.14e-3
+    arw_d_in: float = 7.14e-3
 
-        self.params = {
-            "datum": datum,  # Offset required to set handicap 0 at desired score.
-            "step": step,  # Percentage change in group size for each handicap step.
-            "ang_0": ang_0,  # Baseline angle used for group size 0.5 [millirad].
-            "k1": k1,  # Constant 1 used in handicap equation.
-            "k2": k2,  # Constant 2 used in handicap equation.
-            "k3": k3,  # Constant 3 used in handicap equation.
-            "p1": p1,  # Exponent of distance scaling.
-        }
+    # Scale parameters
+    desc_scale: bool = True
+    scale_bounds: Sequence[float] = [-75, 300]
+    max_score_rounding_lim: float = 0.5
 
-        self.arw_d_out = 7.14e-3
-        self.arw_d_in = 7.14e-3
-
-        self.name = "AGBold"
-        self.max_score_rounding_lim: float = 0.5
+    # Handicap scheme equation specific parameters
+    datum: float = 12.9  # Offset required to set handicap 0 at desired score.
+    step: float = 3.6  # Percentage change in group size for each handicap step.
+    ang_0: float = 5.0e-4  # Baseline angle used for group size 0.5 [millirad].
+    k1: float = 1.429e-6   # Constant 1 used in handicap equation.
+    k2: float = 1.07       # Constant 2 used in handicap equation.
+    k3: float = 4.3        # Constant 3 used in handicap equation.
+    p1: float = 2.0        # Exponent of distance scaling.
 
     def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
@@ -272,12 +263,12 @@ class HandicapAGBold(HandicapScheme):
         array([0.00112649, 0.00478762, 0.05520862])
 
         """
-        k_factor = self.params["k1"] * self.params["k2"] ** (
-            handicap + self.params["k3"]
+        k_factor = self.k1 * self.k2 ** (
+            handicap + self.k3
         )
-        f_factor = 1.0 + k_factor * dist ** self.params["p1"]
+        f_factor = 1.0 + k_factor * dist ** self.p1
         return (
-            self.params["ang_0"]
-            * ((1.0 + self.params["step"] / 100.0) ** (handicap + self.params["datum"]))
+            self.ang_0
+            * ((1.0 + self.step / 100.0) ** (handicap + self.datum))
             * f_factor
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.20.0",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This MR to the ongoing #78 implements pydantic as a way of tackling some of the issues raised in review.
Specifically that of taking numerical parameters out of the base class making it truly generic and implementing the 

Pro:
- Makes the code more secure and intuitive
- May make setting of scheme specific parameters even easier

Con:
- Adds a dependency, but useful.
- Makes it harder for people to contribute as they may need to get up to speed on pydantic

Ambivalent:
- There is probably much more that could be done with a move to be a Pydantic model.
  Should we leverage some of that?
  Is pydantic overkill for what we are trying to achieve here?

TODO:
- [ ] Check how we now set/override certain parameters in the child classes.
- [ ] Update the `handicap_scheme()` function to work with this.
- [ ] Update docs and docstrings