### PR TITLE
BugFix: definition of the WA Field scoring system.

### DIFF
--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -284,7 +284,7 @@ class HandicapScheme(ABC):
                 - np.exp(-((((tar_dia / 20.0) + arw_rad) / sig_r) ** 2))
                 - sum(
                     np.exp(-((((n * tar_dia / 10.0) + arw_rad) / sig_r) ** 2))
-                    for n in range(2, 7)
+                    for n in range(1, 6)
                 )
             )
 

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -340,7 +340,7 @@ class TestArrowScore:
             ("10_zone_6_ring", 7.397557278),
             ("10_zone_5_ring", 7.059965360),
             ("10_zone_5_ring_compound", 6.993772436),
-            ("WA_field", 4.807397627),
+            ("WA_field", 4.115600784),
             ("IFAA_field", 4.265744101),
             ("IFAA_field_expert", 4.021942762),
             ("Beiter_hit_miss", 0.9998380401),


### PR DESCRIPTION
Fixes #85.

Incorrect ranges in the definition of the WA Field scoring system making targets (and therefore predicted scores) too large.
Spotted by @TomHall2020.