### PR TITLE
Clean method lists

### DIFF
--- a/archeryutils/classifications/tests/test_agb_field.py
+++ b/archeryutils/classifications/tests/test_agb_field.py
@@ -13,20 +13,7 @@ ALL_AGBFIELD_ROUNDS = load_rounds.read_json_to_round_dict(
 
 
 class TestAgbFieldClassificationScores:
-    """
-    Class to test the field classification scores function.
-
-    Methods
-    -------
-    test_agb_field_classification_scores_ages()
-        test if expected scores returned for different ages
-    test_agb_field_classification_scores_genders()
-        test if expected scores returned for different genders
-    test_agb_field_classification_scores_bowstyles()
-        test if expected scores returned for different bowstyles
-    test_agb_field_classification_scores_invalid()
-        test invalid inputs
-    """
+    """Tests for the field classification scores function."""
 
     @pytest.mark.parametrize(
         "roundname,age_group,scores_expected",
@@ -220,16 +207,7 @@ class TestAgbFieldClassificationScores:
 
 
 class TestCalculateAgbFieldClassification:
-    """
-    Class to test the field classification function.
-
-    Methods
-    -------
-    test_calculate_agb_field_classification_scores()
-        test if expected sanitised groupname returned
-    test_calculate_agb_field_classification()
-        test if expected full-face roundname returned
-    """
+    """Tests for the field classification function."""
 
     @pytest.mark.parametrize(
         "roundname,score,age_group,bowstyle,class_expected",

--- a/archeryutils/classifications/tests/test_agb_indoor.py
+++ b/archeryutils/classifications/tests/test_agb_indoor.py
@@ -15,25 +15,10 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 
 class TestAgbIndoorClassificationScores:
     """
-    Class to test the agb indoor classification scores function.
+    Tests for the agb indoor classification scores function.
 
     This will implicitly check the dictionary creation.
     Provided sufficient options are covered across bowstyles, genders, and ages.
-
-    Methods
-    -------
-    test_agb_indoor_classification_scores_ages()
-        test if expected scores returned for different ages
-    test_agb_indoor_classification_scores_genders()
-        test if expected scores returned for different genders
-    test_agb_indoor_classification_scores_bowstyles()
-        test if expected scores returned for different bowstyles
-    test_agb_indoor_classification_scores_triple_faces()
-        test if triple faces return full face scores
-    test_agb_indoor_classification_scores_invalid()
-        test invalid inputs
-    test_agb_indoor_classification_scores_invalid_round
-        test invalid roundname
     """
 
     @pytest.mark.parametrize(
@@ -292,20 +277,7 @@ class TestAgbIndoorClassificationScores:
 
 
 class TestCalculateAgbIndoorClassification:
-    """
-    Class to test the indoor classification function.
-
-    Methods
-    -------
-    test_calculate_agb_indoor_classification_scores()
-        test if expected sanitised groupname returned
-    test_calculate_agb_indoor_classification()
-        test if expected full-face roundname returned
-    test_calculate_agb_indoor_classification_invalid_round()
-        check corrrect error raised for invalid rounds
-    test_calculate_agb_indoor_classification_invalid_scores()
-        check corrrect error raised for invalid scores
-    """
+    """Tests for the indoor classification function."""
 
     @pytest.mark.parametrize(
         "score,age_group,bowstyle,class_expected",

--- a/archeryutils/classifications/tests/test_agb_old_indoor.py
+++ b/archeryutils/classifications/tests/test_agb_old_indoor.py
@@ -14,22 +14,7 @@ ALL_INDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 
 
 class TestAgbOldIndoorClassificationScores:
-    """
-    Class to test the old_indoor classification scores function.
-
-    Methods
-    -------
-    test_agb_old_indoor_classification_scores_ages()
-        test if expected scores returned for different ages
-    test_agb_old_indoor_classification_scores_genders()
-        test if expected scores returned for different genders
-    test_agb_old_indoor_classification_scores_bowstyles()
-        test if expected scores returned for different bowstyles
-    test_agb_old_indoor_classification_scores_gent_compound_worcester
-        test supposed loophole in worcester for gent compound
-    test_agb_old_indoor_classification_scores_invalid()
-        test invalid inputs
-    """
+    """Tests for the old_indoor classification scores function."""
 
     @pytest.mark.parametrize(
         "age_group,scores_expected",
@@ -172,14 +157,7 @@ class TestAgbOldIndoorClassificationScores:
 
 
 class TestCalculateAgbOldIndoorClassification:
-    """
-    Class to test the old_indoor classification function.
-
-    Methods
-    -------
-    test_calculate_agb_old_indoor_classification()
-    test_calculate_agb_old_indoor_classification_invalid_scores()
-    """
+    """Tests for the old_indoor classification function."""
 
     @pytest.mark.parametrize(
         "score,gender,class_expected",

--- a/archeryutils/classifications/tests/test_agb_outdoor.py
+++ b/archeryutils/classifications/tests/test_agb_outdoor.py
@@ -1,4 +1,4 @@
-"""Tests for agb indoor classification functions."""
+"""Tests for agb outdoor classification functions."""
 
 import pytest
 
@@ -16,25 +16,10 @@ ALL_OUTDOOR_ROUNDS = load_rounds.read_json_to_round_dict(
 
 class TestAgbOutdoorClassificationScores:
     """
-    Class to test the agb outdoor classification scores function.
+    Tests for the agb outdoor classification scores function.
 
     This will implicitly check the dictionary creation.
     Provided sufficient options are covered across bowstyles, genders, and ages.
-
-    Methods
-    -------
-    test_agb_outdoor_classification_scores_ages()
-        test if expected scores returned for different ages
-    test_agb_outdoor_classification_scores_genders()
-        test if expected scores returned for different genders
-    test_agb_outdoor_classification_scores_bowstyles()
-        test if expected scores returned for different bowstyles
-    test_agb_outdoor_classification_scores_triple_faces()
-        test if triple faces return full face scores
-    test_agb_outdoor_classification_scores_invalid()
-        test invalid inputs
-    test_agb_outdoor_classification_scores_invalid_round
-        test invalid roundname
     """
 
     @pytest.mark.parametrize(
@@ -333,20 +318,7 @@ class TestAgbOutdoorClassificationScores:
 
 
 class TestCalculateAgbOutdoorClassification:
-    """
-    Class to test the outdoor classification function.
-
-    Methods
-    -------
-    test_calculate_agb_outdoor_classification()
-        test if expected full-face roundname returned
-    test_calculate_agb_outdoor_classification_prestige()
-        check prestige round are working
-    test_calculate_agb_outdoor_classification_invalid_round()
-        check corrrect error raised for invalid rounds
-    test_calculate_agb_outdoor_classification_invalid_scores()
-        check corrrect error raised for invalid scores
-    """
+    """Tests for the outdoor classification function."""
 
     @pytest.mark.parametrize(
         "roundname,score,age_group,bowstyle,class_expected",

--- a/archeryutils/classifications/tests/test_classification_utils.py
+++ b/archeryutils/classifications/tests/test_classification_utils.py
@@ -6,16 +6,7 @@ import archeryutils.classifications.classification_utils as class_utils
 
 
 class TestStringUtils:
-    """
-    Class to test the get_groupname() function of handicap_equations.
-
-    Methods
-    -------
-    test_get_groupname()
-        test if expected sanitised groupname returned
-    test_strip_spots()
-        test if expected full-face roundname returned
-    """
+    """Tests for the string formatting utils of classifications code."""
 
     @pytest.mark.parametrize(
         "bowstyle,age_group,gender,groupname_expected",

--- a/archeryutils/handicaps/tests/test_handicap_tables.py
+++ b/archeryutils/handicaps/tests/test_handicap_tables.py
@@ -34,18 +34,7 @@ roundlist = [york, hereford, metric122_30]
 
 
 class TestHandicapTable:
-    """Class to test the handicap table functionalities of handicap_functions.
-
-    Methods
-    -------
-    test_format_row
-    test_table_as_str
-    test_print_agb
-    test_print_aa
-    test_check_print_table_inputs_invalid_rounds
-    test_check_print_table_inputs_invalid_handicaps
-
-    """
+    """Tests for the handicap table functionalities of the HandicapTable class."""
 
     def test_repr(self) -> None:
         """Check HandicapTable representation."""
@@ -222,54 +211,3 @@ class TestHandicapTable:
             match=("Expected float or ndarray for hcs."),
         ):
             hc.HandicapTable("AGB", "a", [york, hereford])  # type: ignore
-
-
-#     @pytest.mark.parametrize(
-#         "input_table,int_prec,sys,expected",
-#         [
-#             (
-#                 np.array([[0, 11, 12, 13], [1, 10, 12, 12]]),
-#                 True,
-#                 "AGB",
-#                 np.array([[0, 11, -9999, 13], [1, 10, 12, 12]]),
-#             ),
-#             (
-#                 np.array([[0, 13], [5, 12], [10, 12], [15, 11]]),
-#                 True,
-#                 "AGB",
-#                 np.array([[0, 13], [5, -9999], [10, 12], [15, 11]]),
-#             ),
-#             (
-#                 np.array([[4, 13], [3, 12], [2, 12], [1, 11]]),
-#                 True,
-#                 "AA",
-#                 np.array([[4, 13], [3, 12], [2, -9999], [1, 11]]),
-#             ),
-#             (
-#                 np.array([[0.0, 11.0, 12.0, 13.0], [1.0, 10.0, 12.0, 12.0]]),
-#                 False,
-#                 "AGB",
-#                 np.array([[0.0, 11.0, np.nan, 13.0], [1.0, 10.0, 12.0, 12.0]]),
-#             ),
-#             (
-#                 np.array([[0.0, 11.5, 12.5, 13.5], [1.0, 11.5, 12.0, 13.5]]),
-#                 False,
-#                 "AGB",
-#                 np.array([[0.0, np.nan, 12.5, np.nan], [1.0, 11.5, 12.0, 13.5]]),
-#             ),
-#         ],
-#     )
-#     def test_clean_repeated(
-#         self,
-#         input_table: NDArray[Union[np.int_, np.float_]],
-#         int_prec: bool,
-#         sys: str,
-#         expected: NDArray[Union[np.int_, np.float_]],
-#     ) -> None:
-#         """
-#         Check that abbreviate returns expected results.
-#         """
-#         print(hc_func.clean_repeated(input_table, int_prec, sys))
-#         np.testing.assert_allclose(
-#             hc_func.clean_repeated(input_table, int_prec, sys), expected
-#         )

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -86,7 +86,7 @@ kings_900_rec = Round(
 
 
 class TestHandicapScheme:
-    """Class to test the handicap_scheme() function creating a HandicapScheme class."""
+    """Tests for the handicap_scheme() function creating a HandicapScheme class."""
 
     @pytest.mark.parametrize(
         "scheme",
@@ -152,18 +152,11 @@ class TestHandicapScheme:
 
 class TestSigmaT:
     """
-    Class to test the sigma_t() function of handicap_equations.
+    Tests for the sigma_t() function of handicap_equations.
 
-    Uses output of the code when run at a particular point in time and then
+    Uses outputs of the code when run at a particular point in time and then
     'frozen' to make sure future developments do not introduce unexpected changes.
     Deliberate changes to the schemes may affect these values and require changes.
-
-    Methods
-    -------
-    test_float()
-        test if expected sigma_t returned from float
-    test_array()
-        test if expected sigma_t returned from array of floats
     """
 
     @pytest.mark.parametrize(
@@ -215,18 +208,11 @@ class TestSigmaT:
 
 class TestSigmaR:
     """
-    Class to test the sigma_r() function of handicap_equations.
+    Tests for the sigma_r() function of handicap_equations.
 
     Uses output of the code when run at a particular point in time and then
     'frozen' to make sure future developments do not introduce unexpected changes.
     Deliberate changes to the schemes may affect these values and require changes.
-
-    Methods
-    -------
-    test_float()
-        test if expected sigma_r returned for from float
-    test_array()
-        test if expected sigma_r returned for from array of floats
     """
 
     @pytest.mark.parametrize(
@@ -278,20 +264,12 @@ class TestSigmaR:
 
 class TestArrowScore:
     """
-    Class to test the arrow_score() function of handicap_equations.
+    Tests for the arrow_score() function of handicap_equations.
 
     Tests all of the different types of target faces.
     Uses output of the code when run at a particular point in time and then
     'frozen' to make sure future developments do not introduce unexpected changes.
     Deliberate changes to the schemes may affect these values and require changes.
-
-
-    Methods
-    -------
-    test_different_handicap_systems()
-        test if expected score returned for different systems
-    test_different_target_faces()
-        test if expected score returned for different faces
     """
 
     @pytest.mark.parametrize(
@@ -430,18 +408,11 @@ class TestArrowScore:
 
 class TestScoreForPasses:
     """
-    Class to test the score_for_passes() function of handicap_equations.
+    Tests for the score_for_passes() function of handicap_equations.
 
     Uses output of the code when run at a particular point in time and then
     'frozen' to make sure future developments do not introduce unexpected changes.
     Deliberate changes to the schemes may affect these values and require changes.
-
-    Methods
-    -------
-    test_float_pass_scores()
-        test if round_score returns expected results
-    test_rounded_pass_scores
-        test if round_score returns expected results when rounding
     """
 
     @pytest.mark.parametrize(
@@ -538,18 +509,11 @@ class TestScoreForPasses:
 
 class TestScoreForRound:
     """
-    Class to test the score_for_round() function of handicap_equations.
+    Tests for the score_for_round() function of handicap_equations.
 
     Uses output of the code when run at a particular point in time and then
     'frozen' to make sure future developments do not introduce unexpected changes.
     Deliberate changes to the schemes may affect these values and require changes.
-
-    Methods
-    -------
-    test_float_round_score()
-        test if round_score returns expected results
-    test_rounded_round_score
-        test if round_score returns expected results when rounding
     """
 
     @pytest.mark.parametrize(
@@ -656,7 +620,7 @@ class TestScoreForRound:
 
 class TestHandicapFromScore:
     """
-    Class to test the handicap_from_score() function of handicap_functions.
+    Tests for the handicap_from_score() function of handicap_functions.
 
     Test both float and integer values, and maximum score.
     Where possible try and perform comparisons using values taken from literature,
@@ -665,15 +629,6 @@ class TestHandicapFromScore:
     - For Archery GB new use the published handicap tables or values from this code.
     - For Archery Australia use Archery Scorepad- [ ] Classifications
     - For Archery Australia 2 there are no published tables and issues exist with
-
-    Methods
-    -------
-    test_score_over_max()
-    test_score_of_zero()
-    test_score_below_zero()
-    test_maximum_score()
-    test_int_precision()
-    test_decimal()
 
     References
     ----------

--- a/archeryutils/tests/test_length.py
+++ b/archeryutils/tests/test_length.py
@@ -108,7 +108,7 @@ class TestLengths:
     def test_optional_unit_parsing_units_not_supported(self):
         """Test parsing of quantities with and without units."""
         with pytest.raises(ValueError, match="Unit (.+) not recognised. Select from"):
-            assert length.parse_optional_units(
+            length.parse_optional_units(
                 (10, "bannana"), length.metre | length.yard, "metre"
             )
 
@@ -117,4 +117,4 @@ class TestLengths:
         with pytest.raises(
             ValueError, match="Default unit (.+) must be in supported units"
         ):
-            assert length.parse_optional_units(10, length.metre | length.yard, "inch")
+            length.parse_optional_units(10, length.metre | length.yard, "inch")

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -11,22 +11,7 @@ _target = Target("5_zone", 122, 50)
 
 
 class TestPass:
-    """
-    Class to test the Pass class.
-
-    Methods
-    -------
-    test_default_distance_unit()
-        test behaviour of default distance unit
-    test_default_location()
-        test behaviour of default location
-    test_negative_arrows()
-        test behaviour of negative arrow number
-    test_properties()
-        test setting of Pass properties
-    test_max_score()
-        test max score functionality of Pass
-    """
+    """Tests for the Pass class."""
 
     def test_init(self) -> None:
         """Check direct initialisation of a Pass with a target instance."""
@@ -153,20 +138,7 @@ class TestPass:
 
 
 class TestRound:
-    """
-    Class to test the Round class.
-
-    Methods
-    -------
-    def test_max_score()
-        test max score functionality of Round
-    def test_max_distance()
-        test max distance functionality of Round
-    test_max_distance_out_of_order()
-        test max distance functionality of Round with unsorted Passes
-    def test_get_info()
-        test get_info functionality of Round
-    """
+    """Tests for the Round class."""
 
     def test_init_with_iterable_passes(self) -> None:
         """

--- a/archeryutils/tests/test_targets.py
+++ b/archeryutils/tests/test_targets.py
@@ -8,16 +8,7 @@ from archeryutils.targets import ScoringSystem, Target
 
 
 class TestTarget:
-    """
-    Class to test the Target class.
-
-    Methods
-    -------
-    def test_invalid_system()
-        test if invalid target face type system raises an error
-    test_invalid_distance_unit()
-        test if invalid distance unit raises an error
-    """
+    """Tests for the Target class."""
 
     def test_repr(self) -> None:
         """Check Target string representation is as expected."""


### PR DESCRIPTION
Closes #83 by removing lists of methods from the testing function.

Users can now instead scroll down the class to see implemented tests and not worry about keeping the master list up to date.
As we move towards release it is assumed future tests will be written to cover any new code, and checked at review.