### PR TITLE
Update coverage workflow.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: |
           pip install coverage
           pip install .[test]
@@ -32,3 +32,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true 
+        token: ${{ secrets.CODECOV_TOKEN }}
+


### PR DESCRIPTION
Use token from secrets to fix failure to upload.
Set to fail if any coverage errors in upload - poor default behaviour.

Boost to use python 3.13