### PR TITLE
Fixes an issue that resulted in division by zero in the rootfinding algorithm

### DIFF
--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -652,7 +652,11 @@ class HandicapScheme(ABC):
 
             if (abs(spre) > delta) and (abs(fcur) < abs(fpre)):
                 if xpre == xblk:
-                    stry = -fcur * (xcur - xpre) / (fcur - xpre)
+                    stry = (
+                        -fcur
+                        * (xcur - xpre)
+                        / ((fcur - xpre) if (fcur - xpre) != 0 else xtol)
+                    )
                 else:
                     dpre = (fpre - fcur) / (xpre - xcur)
                     dblk = (fblk - fcur) / (xblk - xcur)


### PR DESCRIPTION
Fixes #108 

Fixes an issue that resulted in division by zero in the rootfinding algorithm

This occurred when the score for which a handicap is requested is the same number of points below the maximum score for a round as one of the arbitrary bounds used to initialise the search interval.

Not a bug per-se, as the algorithm is robust enough to handle division by zero and select a better interval to return the 'correct' handicap, but resulted in a warniong being printed to the repl or stdout.
This is resolved by replacing the zero with a small number (xtol already in the function) when it occurs.

Returned handicaps may now be different in this instance by the 6th sig fig point, but this is within the tolerance that archeryutils purports to give and all tests still pass.