### PR TITLE
Data looping in classification dict generation functions

### DIFF
--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -124,21 +124,22 @@ def _assign_dists(
     age: cls_funcs.AGBAgeData,
 ) -> tuple[npt.NDArray[np.int64], int]:
     """
-    Assign appropriate minimum distance required for a category and classification.
+    Assign appropriate distance required for a category and classification.
 
-    Appropriate for 2024 ArcheryGB age groups and classifications.
+    Appropriate for 2025 ArcheryGB field age groups and classifications.
 
     Parameters
     ----------
     bowstyle : str,
         string defining bowstyle
     age : dict[str, any],
-        dict containing age group data
+        Typed dict containing age group data
 
     Returns
     -------
-    dists : list[float]
-        [minimum, maximum] distances required for this classification
+    tuple
+        ndarray of minimum distances required for each classification for this bowstyle
+        int of maximum distance that is shot by this bowstyle
 
     References
     ----------
@@ -162,6 +163,8 @@ def _assign_dists(
 
     n_classes: int = 9  # [EMB, GMB, MB, B1, B2, B3, A1, A2, A3]
 
+    # EMB to bowman requires a minimum appropriate distance
+    # Archer tiers can be shot at shorter pegs (min dist reduced by 10m for each tier)
     min_dists = np.zeros(n_classes, dtype=np.int64)
     min_dists[0:6] = min_d
     min_dists[6:9] = np.maximum(min_d - 10 * np.arange(1, 4), 30)

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -32,7 +32,7 @@ class GroupData(TypedDict):
     classes_long: list[str]
     class_HC: npt.NDArray[np.float64]
     max_distance: int
-    min_dists: npt.NDArray[np.float64]
+    min_dists: npt.NDArray[np.int64]
 
 
 def _make_agb_field_classification_dict() -> dict[str, GroupData]:
@@ -104,7 +104,7 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
             bowstyle["datum_field"]
             + delta_hc_age_gender
             + (np.arange(len(agb_classes_field)) - 2) * bowstyle["classStep_field"]
-        )
+        ).astype(np.float64)
 
         groupdata: GroupData = {
             "classes": agb_classes_field,
@@ -122,7 +122,7 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
 def _assign_dists(
     bowstyle: str,
     age: cls_funcs.AGBAgeData,
-) -> list[int]:
+) -> tuple[npt.NDArray[np.int64], int]:
     """
     Assign appropriate minimum distance required for a category and classification.
 
@@ -162,7 +162,7 @@ def _assign_dists(
 
     n_classes: int = 9  # [EMB, GMB, MB, B1, B2, B3, A1, A2, A3]
 
-    min_dists = np.empty(n_classes)
+    min_dists = np.zeros(n_classes, dtype=np.int64)
     min_dists[0:6] = min_d
     min_dists[6:9] = np.maximum(min_d - 10 * np.arange(1, 4), 30)
 

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -31,8 +31,8 @@ class GroupData(TypedDict):
     classes: list[str]
     classes_long: list[str]
     class_HC: npt.NDArray[np.float64]
-    max_distance: int
-    min_dists: npt.NDArray[np.int64]
+    max_distance: float
+    min_dists: npt.NDArray[np.float64]
 
 
 def _make_agb_field_classification_dict() -> dict[str, GroupData]:
@@ -122,7 +122,7 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
 def _assign_dists(
     bowstyle: str,
     age: cls_funcs.AGBAgeData,
-) -> tuple[npt.NDArray[np.int64], int]:
+) -> tuple[npt.NDArray[np.float64], float]:
     """
     Assign appropriate distance required for a category and classification.
 
@@ -165,7 +165,7 @@ def _assign_dists(
 
     # EMB to bowman requires a minimum appropriate distance
     # Archer tiers can be shot at shorter pegs (min dist reduced by 10m for each tier)
-    min_dists = np.zeros(n_classes, dtype=np.int64)
+    min_dists = np.zeros(n_classes, dtype=np.float64)
     min_dists[0:6] = min_d
     min_dists[6:9] = np.maximum(min_d - 10 * np.arange(1, 4), 30)
 

--- a/archeryutils/classifications/agb_field_classifications.py
+++ b/archeryutils/classifications/agb_field_classifications.py
@@ -8,6 +8,7 @@ calculate_agb_field_classification
 agb_field_classification_scores
 """
 
+import itertools
 from typing import Any, TypedDict
 
 import numpy as np
@@ -76,55 +77,54 @@ def _make_agb_field_classification_dict() -> dict[str, GroupData]:
     agb_classes_field = agb_classes_info_field["classes"]
     agb_classes_field_long = agb_classes_info_field["classes_long"]
 
+
     # Generate dict of classifications
-    # loop over bowstyles
-    # loop over genders
-    # loop over ages
+    # loop over all bowstyles, genders, ages
     classification_dict = {}
-    for bowstyle in agb_bowstyles:
-        for gender in agb_genders:
-            for age in agb_ages:
-                groupname = cls_funcs.get_groupname(
-                    bowstyle["bowstyle"], gender, age["age_group"]
-                )
+    for bowstyle, gender, age in itertools.product(
+        agb_bowstyles, agb_genders, agb_ages
+    ):
+        groupname = cls_funcs.get_groupname(
+            bowstyle["bowstyle"], gender, age["age_group"]
+        )
 
-                # Get max dists for category from json file data
-                # Use metres as corresponding yards >= metric
-                dists = _assign_dists(bowstyle["bowstyle"], age)
+        # Get max dists for category from json file data
+        # Use metres as corresponding yards >= metric
+        dists = _assign_dists(bowstyle["bowstyle"], age)
 
-                # set step from datum based on age and gender steps required
-                delta_hc_age_gender = cls_funcs.get_age_gender_step(
-                    gender,
-                    age["step"],
-                    bowstyle["ageStep_field"],
-                    bowstyle["genderStep_field"],
-                )
+        # set step from datum based on age and gender steps required
+        delta_hc_age_gender = cls_funcs.get_age_gender_step(
+            gender,
+            age["step"],
+            bowstyle["ageStep_field"],
+            bowstyle["genderStep_field"],
+        )
 
-                classifications_count = len(agb_classes_field)
+        classifications_count = len(agb_classes_field)
 
-                class_hc = np.empty(classifications_count)
+        class_hc = np.empty(classifications_count)
 
-                min_dists = np.empty(classifications_count)
-                min_dists[0:6] = dists[0]
-                min_dists[6:9] = [max(dists[0] - 10 * i, 30) for i in range(1, 4)]
+        min_dists = np.empty(classifications_count)
+        min_dists[0:6] = dists[0]
+        min_dists[6:9] = [max(dists[0] - 10 * i, 30) for i in range(1, 4)]
 
-                for i in range(classifications_count):
-                    # Assign handicap for this classification
-                    class_hc[i] = (
-                        bowstyle["datum_field"]
-                        + delta_hc_age_gender
-                        + (i - 2) * bowstyle["classStep_field"]
-                    )
+        for i in range(classifications_count):
+            # Assign handicap for this classification
+            class_hc[i] = (
+                bowstyle["datum_field"]
+                + delta_hc_age_gender
+                + (i - 2) * bowstyle["classStep_field"]
+            )
 
-                groupdata: GroupData = {
-                    "classes": agb_classes_field,
-                    "classes_long": agb_classes_field_long,
-                    "class_HC": class_hc,
-                    "max_distance": dists[1],
-                    "min_dists": min_dists,
-                }
+        groupdata: GroupData = {
+            "classes": agb_classes_field,
+            "classes_long": agb_classes_field_long,
+            "class_HC": class_hc,
+            "max_distance": dists[1],
+            "min_dists": min_dists,
+        }
 
-                classification_dict[groupname] = groupdata
+        classification_dict[groupname] = groupdata
 
     return classification_dict
 

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -98,7 +98,7 @@ def _make_agb_indoor_classification_dict() -> dict[str, GroupData]:
             bowstyle["datum_in"]
             + delta_hc_age_gender
             + (np.arange(len(agb_classes_in)) - 1) * bowstyle["classStep_in"]
-        )
+        ).astype(np.float64)
 
         groupdata: GroupData = {
             "classes": agb_classes_in,

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -7,6 +7,7 @@ calculate_agb_indoor_classification
 agb_indoor_classification_scores
 """
 
+import itertools
 from typing import TypedDict
 
 import numpy as np
@@ -73,44 +74,42 @@ def _make_agb_indoor_classification_dict() -> dict[str, GroupData]:
     agb_classes_in_long = agb_classes_info_in["classes_long"]
 
     # Generate dict of classifications
-    # loop over bowstyles
-    # loop over ages
-    # loop over genders
+    # loop over all bowstyles, genders, ages
     classification_dict = {}
-    for bowstyle in agb_bowstyles:
-        for gender in agb_genders:
-            for age in agb_ages:
-                groupname = cls_funcs.get_groupname(
-                    bowstyle["bowstyle"],
-                    gender,
-                    age["age_group"],
-                )
+    for bowstyle, gender, age in itertools.product(
+        agb_bowstyles, agb_genders, agb_ages
+    ):
+        groupname = cls_funcs.get_groupname(
+            bowstyle["bowstyle"],
+            gender,
+            age["age_group"],
+        )
 
-                # set step from datum based on age and gender steps required
-                delta_hc_age_gender = cls_funcs.get_age_gender_step(
-                    gender,
-                    age["step"],
-                    bowstyle["ageStep_in"],
-                    bowstyle["genderStep_in"],
-                )
+        # set step from datum based on age and gender steps required
+        delta_hc_age_gender = cls_funcs.get_age_gender_step(
+            gender,
+            age["step"],
+            bowstyle["ageStep_in"],
+            bowstyle["genderStep_in"],
+        )
 
-                classifications_count = len(agb_classes_in)
+        classifications_count = len(agb_classes_in)
 
-                class_hc = np.empty(classifications_count)
-                for i in range(classifications_count):
-                    # Assign handicap for this classification
-                    class_hc[i] = (
-                        bowstyle["datum_in"]
-                        + delta_hc_age_gender
-                        + (i - 1) * bowstyle["classStep_in"]
-                    )
+        class_hc = np.empty(classifications_count)
+        for i in range(classifications_count):
+            # Assign handicap for this classification
+            class_hc[i] = (
+                bowstyle["datum_in"]
+                + delta_hc_age_gender
+                + (i - 1) * bowstyle["classStep_in"]
+            )
 
-                groupdata: GroupData = {
-                    "classes": agb_classes_in,
-                    "classes_long": agb_classes_in_long,
-                    "class_HC": class_hc,
-                }
-                classification_dict[groupname] = groupdata
+        groupdata: GroupData = {
+            "classes": agb_classes_in,
+            "classes_long": agb_classes_in_long,
+            "class_HC": class_hc,
+        }
+        classification_dict[groupname] = groupdata
 
     return classification_dict
 

--- a/archeryutils/classifications/agb_indoor_classifications.py
+++ b/archeryutils/classifications/agb_indoor_classifications.py
@@ -93,16 +93,12 @@ def _make_agb_indoor_classification_dict() -> dict[str, GroupData]:
             bowstyle["genderStep_in"],
         )
 
-        classifications_count = len(agb_classes_in)
-
-        class_hc = np.empty(classifications_count)
-        for i in range(classifications_count):
-            # Assign handicap for this classification
-            class_hc[i] = (
-                bowstyle["datum_in"]
-                + delta_hc_age_gender
-                + (i - 1) * bowstyle["classStep_in"]
-            )
+        # set handicap threshold values for all classifications in the category
+        class_hc = (
+            bowstyle["datum_in"]
+            + delta_hc_age_gender
+            + (np.arange(len(agb_classes_in)) - 1) * bowstyle["classStep_in"]
+        )
 
         groupdata: GroupData = {
             "classes": agb_classes_in,

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -33,7 +33,7 @@ class GroupData(TypedDict):
     max_distance: list[int]
     classes_long: list[str]
     class_HC: npt.NDArray[np.float64]
-    min_dists: npt.NDArray[np.float64]
+    min_dists: npt.NDArray[np.int64]
     prestige_rounds: list[str]
 
 
@@ -103,7 +103,7 @@ def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
             bowstyle["datum_out"]
             + delta_hc_age_gender
             + (np.arange(len(agb_classes_out)) - 2) * bowstyle["classStep_out"]
-        )
+        ).astype(np.float64)
 
         # get minimum distances to be shot for all classifications in the category
         min_dists = _assign_min_dist(
@@ -136,7 +136,7 @@ def _assign_min_dist(
     gender: str,
     age_group: str,
     max_dists: list[int],
-) -> npt.NDArray[int]:
+) -> npt.NDArray[np.int64]:
     """
     Assign appropriate minimum distance required for a category and classification.
 

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -30,10 +30,10 @@ class GroupData(TypedDict):
     """Structure for AGB Outdoor classification data."""
 
     classes: list[str]
-    max_distance: list[int]
+    max_distance: list[float]
     classes_long: list[str]
     class_HC: npt.NDArray[np.float64]
-    min_dists: npt.NDArray[np.int64]
+    min_dists: npt.NDArray[np.float64]
     prestige_rounds: list[str]
 
 
@@ -135,8 +135,8 @@ def _make_agb_outdoor_classification_dict() -> dict[str, GroupData]:
 def _assign_min_dist(
     gender: str,
     age_group: str,
-    max_dists: list[int],
-) -> npt.NDArray[np.int64]:
+    max_dists: list[float],
+) -> npt.NDArray[np.float64]:
     """
     Assign appropriate minimum distance required for a category and classification.
 
@@ -196,7 +196,7 @@ def _assign_outdoor_prestige(
     bowstyle: str,
     gender: str,
     age: str,
-    max_dist: list[int],
+    max_dist: list[float],
 ) -> list[str]:
     """
     Assign appropriate outdoor prestige rounds for a category.

--- a/archeryutils/classifications/agb_outdoor_classifications.py
+++ b/archeryutils/classifications/agb_outdoor_classifications.py
@@ -154,7 +154,7 @@ def _assign_min_dist(
     Returns
     -------
     min_dists : array of int
-        minimum distance [m] required for this category
+        minimum distance [m] required by category for each classification (EMB -> A3)
 
     References
     ----------
@@ -189,6 +189,7 @@ def _assign_min_dist(
     else:
         idxs = np.array([0, 0, 0, 0, 0, 1, 2, 3, 4])
 
+    # Extract relevant distances for each classification from the dists array
     return np.take(dists, idxs + max_dist_index, mode="clip")
 
 

--- a/archeryutils/classifications/classification_utils.py
+++ b/archeryutils/classifications/classification_utils.py
@@ -23,10 +23,10 @@ class AGBAgeData(TypedDict):
 
     desc: str
     age_group: str
-    male: list[int]
-    female: list[int]
-    red: list[int]
-    blue: list[int]
+    male: list[float]
+    female: list[float]
+    red: list[float]
+    blue: list[float]
     step: int
 
 


### PR DESCRIPTION
As discussed in #103, the classification data generation functions can be unindented quite nicely by replacing direct iteration over bowstyle/gender/age divisions with the itertools product of those.

Implementing that was very straightforward, but while I was in there I did smell an opportunity to excise another bit of looping, where the class handicap thresholds and minimum distances themselves are built up by manual iteration over the indecies of the classification labels. That took a bit more effort, but I think is much more explicit this way, and the result is that the loop building up the classification data is now pretty much solely packaging things nicely, and has a minimum of inline logic. 

Inside the agb_outdoor `_assign_min_dist` function I could come up with various ways to build up the required indecies based on the number of mb_categories and adjustments etc, but in the end I felt that just declaring it completely explicitly was the most readable and clear way to do it. The use of `np.take` with `mode="clip"` works really nicely to get rid of the try/except index error handling.

There are still some magic numbers (1 and 2) for offsetting the indecies when using the age/gender steps but since I have absolutely no idea why they were there before I can't do much do make them more explicit here. 

No tests broken, so just up to you @jatkinson1000 if you're happy with the new division of logic?
