### PR TITLE
Round narrows

### DIFF
--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -177,6 +177,8 @@ class Round:
         string identifing the governing body the round belongs to
     family : str or None
         string identifing the family the round belongs to (e.g. wa1440, western, etc.)
+    n_arrows : int
+        total number of arrows in this round
 
     Examples
     --------
@@ -214,6 +216,7 @@ class Round:
         self.location = location
         self.body = body
         self.family = family
+        self.n_arrows: int = sum(pass_i.n_arrows for pass_i in self.passes)
 
     def __repr__(self) -> str:
         """Return a representation of a Round instance."""

--- a/archeryutils/tests/test_rounds.py
+++ b/archeryutils/tests/test_rounds.py
@@ -246,6 +246,41 @@ class TestRound:
 
         assert round_ != ("Test", [pass_, pass_])
 
+    @pytest.mark.parametrize(
+        "passes,result",
+        [
+            pytest.param(
+                [
+                    Pass.at_target(100, "5_zone", 122, 50, False),
+                    Pass.at_target(100, "5_zone", 122, 40, False),
+                    Pass.at_target(100, "5_zone", 122, 30, False),
+                ],
+                300,
+            ),
+            pytest.param(
+                [
+                    Pass.at_target(100, "5_zone", 122, 50, False),
+                ],
+                100,
+            ),
+            pytest.param(
+                [
+                    Pass.at_target(100, "5_zone", 122, 50, False),
+                    Pass.at_target(50, "5_zone", 122, 40, False),
+                    Pass.at_target(25, "5_zone", 80, 30, False),
+                ],
+                175,
+            ),
+        ],
+    )
+    def test_n_arrows(self, passes: Iterable, result: int) -> None:
+        """Check that n_arrows attribute is calculated correctly for a Round."""
+        test_round = Round(
+            "MyRound",
+            passes,
+        )
+        assert test_round.n_arrows == result
+
     def test_max_score(self) -> None:
         """Check that max score is calculated correctly for a Round."""
         test_round = Round(

--- a/docs/develop/whats-new.rst
+++ b/docs/develop/whats-new.rst
@@ -1,6 +1,15 @@
 What's New
 ==========
 
+Latest
+------
+* Adds `n_arrows` attribute to `Round`.
+* Fixes issue whereby a divide-by-zero warning could arise in the handicap rootfinding
+  algorithm.
+* Update to latest ruff and mypy.
+* Bugfix: Field classification naming made consistent with other schemes.
+
+
 Version 1.1.1
 -------------
 * Fixes a bug in version 1.1.0 whereby shorter-peg rounds were not restricted to


### PR DESCRIPTION
Adds `n_arrows` attribute to rounds as inexpensive and useful to be exposed at the top level rather than calculated from `passes`.