### PR TITLE
Add new AGB900 rounds.

### DIFF
--- a/archeryutils/round_data_files/AGB_outdoor_metric.json
+++ b/archeryutils/round_data_files/AGB_outdoor_metric.json
@@ -121,7 +121,6 @@
   },
 
 
-
   {"name" : "Short Metric",
    "codename" : "short_metric",
    "location" : "outdoor",
@@ -231,4 +230,57 @@
    "passes" : [{"n_arrows" : 36, "diameter" : 80, "scoring" : "10_zone", "distance" : 30, "dist_unit" : "metre"},
                {"n_arrows" : 36, "diameter" : 80, "scoring" : "10_zone", "distance" : 30, "dist_unit" : "metre"}
               ]
-  }]
+  },
+
+
+  {"name" : "AGB 900 70",
+   "codename" : "agb900_70",
+   "location" : "outdoor",
+   "body" : "AGB",
+   "family" : "agb900",
+   "passes" : [{"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 70, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 60, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 50, "dist_unit" : "metre"}
+              ]
+  },
+  {"name" : "AGB 900 60",
+   "codename" : "agb900_60",
+   "location" : "outdoor",
+   "body" : "AGB",
+   "family" : "agb900",
+   "passes" : [{"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 60, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 50, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 40, "dist_unit" : "metre"}
+              ]
+  },
+  {"name" : "AGB 900 50",
+   "codename" : "agb900_50",
+   "location" : "outdoor",
+   "body" : "AGB",
+   "family" : "agb900",
+   "passes" : [{"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 50, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 40, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 30, "dist_unit" : "metre"}
+              ]
+  },
+  {"name" : "AGB 900 40",
+   "codename" : "agb900_40",
+   "location" : "outdoor",
+   "body" : "AGB",
+   "family" : "agb900",
+   "passes" : [{"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 40, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 30, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 20, "dist_unit" : "metre"}
+              ]
+  },
+  {"name" : "AGB 900 30",
+   "codename" : "agb900_30",
+   "location" : "outdoor",
+   "body" : "AGB",
+   "family" : "agb900",
+   "passes" : [{"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 30, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 20, "dist_unit" : "metre"},
+               {"n_arrows" : 30, "diameter" : 122, "scoring" : "10_zone", "distance" : 10, "dist_unit" : "metre"}
+              ]
+  }
+]

--- a/docs/develop/whats-new.rst
+++ b/docs/develop/whats-new.rst
@@ -3,6 +3,7 @@ What's New
 
 Latest
 ------
+* Add new AGB 900 rounds in `#116 <https://github.com/jatkinson1000/archeryutils/pull/116>`_
 * Adds `n_arrows` attribute to `Round`.
 * Fixes issue whereby a divide-by-zero warning could arise in the handicap rootfinding
   algorithm.


### PR DESCRIPTION
Adds new AGB900 rounds as per https://archerygb.org/news/new-round-created-for-the-2025-junior-national-outdoor-championships

Listed from 70 down to 30 in AGB Metric outdoor rounds.