### PR TITLE
Pin sphinx at <2.8.0 due to known issues.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "archeryutils"
 copyright = "2024, Jack Atkinson"
 author = "Jack Atkinson"
-release = "0.0.0"
+release = "1.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ lint = [
     "blackdoc",
 ]
 docs = [
-    "sphinx",
+    "sphinx<8.2.0",
     "sphinx_rtd_theme",
     "sphinx-toolbox",
     "nbsphinx",


### PR DESCRIPTION
See: https://github.com/sphinx-doc/sphinx/issues/13362 and https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523