### PR TITLE
[WIP] archeryutils.django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,11 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+#
+#   For package development, Pipenv can be useful for local virtualenv management but is not
+#   needed by others.
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/archeryutils/__init__.py
+++ b/archeryutils/__init__.py
@@ -1,6 +1,6 @@
 """Package providing code for various archery utilities."""
 
-from archeryutils import classifications, handicaps
+from archeryutils import classifications, django, handicaps
 from archeryutils.rounds import Pass, Round
 from archeryutils.targets import Quantity, Target
 from archeryutils.utils import versions
@@ -11,6 +11,7 @@ __all__ = [
     "Round",
     "Target",
     "classifications",
+    "django",
     "handicaps",
     "versions",
 ]

--- a/archeryutils/django/fields.py
+++ b/archeryutils/django/fields.py
@@ -1,0 +1,54 @@
+from django.db import models
+
+from archeryutils.rounds import Round
+
+
+class RoundField(models.CharField):
+    description = "Choose from a set of archery rounds"
+
+    def __init__(self, rounds, **kwargs):
+        self.rounds = rounds
+        self._round_dict = rounds  # TOOD: allow more complex round structures to be passed
+
+        # TODO Hack for deconstruction for now
+        if isinstance(rounds, list):
+            self._round_dict = {r: r for r in rounds}
+
+        kwargs.setdefault("max_length", 64)
+        super().__init__(**kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        # TODO - round deconstruction
+        kwargs["rounds"] = list(self._round_dict.keys())
+        return name, path, args, kwargs
+
+    @property
+    def non_db_attrs(self):
+        return super().non_db_attrs + ("rounds",)
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        return self._round_dict[value]
+
+    def to_python(self, value):
+        if isinstance(value, Round):
+            return value.codename
+
+        if value is None:
+            return value
+
+        if value in self.rounds:
+            return self._round_dict[value]
+
+        raise ValueError("Round unknown")
+
+    def get_prep_value(self, value):
+        if isinstance(value, Round):
+            return value.codename
+        return value
+
+    def formfield(self, **kwargs):
+        from . import forms
+        return forms.RoundField(rounds=self.rounds, required=not self.blank)

--- a/archeryutils/django/fields.py
+++ b/archeryutils/django/fields.py
@@ -8,7 +8,9 @@ class RoundField(models.CharField):
 
     def __init__(self, rounds, **kwargs):
         self.rounds = rounds
-        self._round_dict = rounds  # TOOD: allow more complex round structures to be passed
+        self._round_dict = (
+            rounds  # TOOD: allow more complex round structures to be passed
+        )
 
         # TODO Hack for deconstruction for now
         if isinstance(rounds, list):
@@ -51,4 +53,5 @@ class RoundField(models.CharField):
 
     def formfield(self, **kwargs):
         from . import forms
+
         return forms.RoundField(rounds=self.rounds, required=not self.blank)

--- a/archeryutils/django/forms.py
+++ b/archeryutils/django/forms.py
@@ -5,10 +5,11 @@ from archeryutils.rounds import Round
 
 
 class RoundField(forms.ChoiceField):
-
     def __init__(self, rounds, **kwargs):
         self.rounds = rounds
-        choices = BLANK_CHOICE_DASH + [(round.codename, round.name) for (codename, round) in rounds.items()]
+        choices = BLANK_CHOICE_DASH + [
+            (round.codename, round.name) for (codename, round) in rounds.items()
+        ]
         kwargs.setdefault("choices", choices)
         super().__init__(**kwargs)
 

--- a/archeryutils/django/forms.py
+++ b/archeryutils/django/forms.py
@@ -1,0 +1,25 @@
+from django import forms
+from django.db.models import BLANK_CHOICE_DASH
+
+from archeryutils.rounds import Round
+
+
+class RoundField(forms.ChoiceField):
+
+    def __init__(self, rounds, **kwargs):
+        self.rounds = rounds
+        choices = BLANK_CHOICE_DASH + [(round.codename, round.name) for (codename, round) in rounds.items()]
+        kwargs.setdefault("choices", choices)
+        super().__init__(**kwargs)
+
+    def clean(self, value):
+        if value in self.rounds:
+            return self.rounds[value]
+        elif value is None:
+            return None
+        raise forms.ValidationError("Round type unknown", code="invalid")
+
+    def prepare_value(self, value):
+        if isinstance(value, Round):
+            return value.codename
+        return value

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -112,6 +112,7 @@ def read_json_to_round_dict(json_filelist: str | list[str]) -> dict[str, Round]:
             round_dict[round_i["codename"]] = Round(
                 round_i["name"],
                 passes,
+                codename=round_i["codename"],
                 location=round_i["location"],
                 body=round_i["body"],
                 family=round_i["family"],

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -200,11 +200,13 @@ class Round:
         self,
         name: str,
         passes: Iterable[Pass],
+        codename: str | None = None,
         location: str | None = None,
         body: str | None = None,
         family: str | None = None,
     ) -> None:
         self.name = name
+        self.codename = codename
         self.passes = list(passes)
         if not self.passes:
             msg = "passes must contain at least one Pass object but none supplied."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+django = [
+    "django>=5",
+]
 test = [
     "pytest>=7.2.0",
     "pytest-mock",


### PR DESCRIPTION
My intention here is to add Django model and form fields to `archeryutils`, to allow for super simple modelling of archery related information, and in a way where it becomes trivial to get handicap or classification data for them.

Structurally, I've created a submodule `archeryutils.django`. Django is a dependency of this submodule, but wouldn't be required for other things. If preferred, I could develop this as a separate module, but there are some tweaks needed in the core codebase to make it work and this felt more collaborative.

### Proposed feature set

- [x] add `archeryutils.django` as a module
- [x] model and form field for `Round`
  - [ ] make deconstruction for migrations work better?
  - [ ] allow an API like `RoundField(rounds=[WA_outdoor, AGB_outdoor_metric, AGB_outdoor_imperial])`
  - [ ] improve the form field so it uses option groups by round family?
- [ ] model and form field for `au.classifications.AGB_ages` (likely based on [django-enumfield](https://pypi.org/project/django-enumfield/))
- [ ] model and form field for `au.classifications.AGB_bowstyles`
- [ ] model and form field for `au.classifications.AGB_genders`
- [ ] `MultiRoundField` - allows you to select a list of rounds, useful for an entry system, might even be good to pass a family to it?

### Projects which can make use of this include:
[SCAYT results system](https://github.com/mjtamlyn/scayt)
[TamlynScore](https://github.com/mjtamlyn/tamlynscore)
[WCA website](https://github.com/mjtamlyn/wallingfordcastle) (for competition entry system, and then being able to pass entry data directly to TamlynScore)

### Guidance
I've not contributed to this before, so I'm not sure what standards I'm expected to match on documentation (both in the code and formally), type hinting, testing etc.