### PR TITLE
Satisfy mypy with cast of return type to FloatArray for _s_bar in handicap calculations.

### DIFF
--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -254,10 +254,13 @@ class HandicapScheme(ABC):
         score_drops = (inner - outer for inner, outer in itr.pairwise(ring_scores))
         max_score = max(ring_scores)
 
-        return max_score - sum(
+        s_bar = max_score - sum(
             score_drop * np.exp(-(((arw_rad + (ring_diam / 2)) / sig_r) ** 2))
             for ring_diam, score_drop in zip(ring_sizes, score_drops, strict=True)
         )
+
+        # Perform a cast to return to satisfy typechecker
+        return cast(FloatArray, s_bar)
 
     def score_for_passes(
         self,


### PR DESCRIPTION
Cast type of _s_bar in handicap scheme to explicitly be FloatArray to satisfy mypy. Mypy is raising issues as detecting it could theoretically be int as well as float.