### PR TITLE
Store codename of the round on the object itself.

### DIFF
--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -68,6 +68,8 @@ def read_json_to_round_dict(json_filelist: str | list[str]) -> dict[str, Round]:
             data = json.load(json_round_file)
 
         for round_i in data:
+            codename = round_i["codename"]
+
             # Assign location
             if "location" not in round_i:
                 round_i["location"] = None
@@ -109,10 +111,10 @@ def read_json_to_round_dict(json_filelist: str | list[str]) -> dict[str, Round]:
                 for pass_i in round_i["passes"]
             ]
 
-            round_dict[round_i["codename"]] = Round(
+            round_dict[codename] = Round(
                 round_i["name"],
                 passes,
-                codename=round_i["codename"],
+                codename=codename,
                 location=round_i["location"],
                 body=round_i["body"],
                 family=round_i["family"],

--- a/archeryutils/load_rounds.py
+++ b/archeryutils/load_rounds.py
@@ -112,6 +112,7 @@ def read_json_to_round_dict(json_filelist: str | list[str]) -> dict[str, Round]:
             round_dict[round_i["codename"]] = Round(
                 round_i["name"],
                 passes,
+                codename=round_i["codename"],
                 location=round_i["location"],
                 body=round_i["body"],
                 family=round_i["family"],

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -157,6 +157,8 @@ class Round:
         Formal name of the round
     passes : iterable of Pass
         an iterable of Pass classes making up the round
+    codename : str or None
+        A machine readable identifier for the round
     location : str or None, default=None
         string identifing where the round is shot
     body : str or None, default=None

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -198,7 +198,7 @@ class Round:
 
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         name: str,
         passes: Iterable[Pass],

--- a/archeryutils/rounds.py
+++ b/archeryutils/rounds.py
@@ -200,11 +200,13 @@ class Round:
         self,
         name: str,
         passes: Iterable[Pass],
+        codename: str | None = None,
         location: str | None = None,
         body: str | None = None,
         family: str | None = None,
     ) -> None:
         self.name = name
+        self.codename = codename
         self.passes = list(passes)
         if not self.passes:
             msg = "passes must contain at least one Pass object but none supplied."


### PR DESCRIPTION
This change allows the rounds to "self identify" in a machine readable format. Applications can therefore take CSVs or JSON data and look up the identified round.

This extracts the "non-Django" bit out of #125 