### PR TITLE
Update type checking to use numpy NDArray and ArrayLike

### DIFF
--- a/archeryutils/classifications/agb_old_indoor_classifications.py
+++ b/archeryutils/classifications/agb_old_indoor_classifications.py
@@ -9,6 +9,9 @@ AGB_old_indoor_classification_scores
 
 from typing import Tuple, TypedDict
 
+import numpy as np
+import numpy.typing as npt
+
 import archeryutils.classifications.classification_utils as cls_funcs
 import archeryutils.handicaps as hc
 from archeryutils import load_rounds
@@ -30,7 +33,7 @@ class GroupData(TypedDict):
     """Structure for old AGB Indoor classification data."""
 
     classes: list[str]
-    class_HC: list[int]
+    class_HC: npt.NDArray[np.float64]
 
 
 def _get_old_indoor_groupname(
@@ -147,19 +150,19 @@ def _make_agb_old_indoor_classification_dict() -> dict[str, GroupData]:
     # for both bowstyles, for both genders
     compound_male_adult: GroupData = {
         "classes": agb_indoor_classes,
-        "class_HC": [5, 12, 24, 37, 49, 62, 73, 79],
+        "class_HC": np.array([5, 12, 24, 37, 49, 62, 73, 79]),
     }
     compound_female_adult: GroupData = {
         "classes": agb_indoor_classes,
-        "class_HC": [12, 18, 30, 43, 55, 67, 79, 83],
+        "class_HC": np.array([12, 18, 30, 43, 55, 67, 79, 83]),
     }
     recurve_male_adult: GroupData = {
         "classes": agb_indoor_classes,
-        "class_HC": [14, 21, 33, 46, 58, 70, 80, 85],
+        "class_HC": np.array([14, 21, 33, 46, 58, 70, 80, 85]),
     }
     recurve_female_adult: GroupData = {
         "classes": agb_indoor_classes,
-        "class_HC": [21, 27, 39, 51, 64, 75, 85, 90],
+        "class_HC": np.array([21, 27, 39, 51, 64, 75, 85, 90]),
     }
 
     classification_dict = {

--- a/archeryutils/handicaps/__init__.py
+++ b/archeryutils/handicaps/__init__.py
@@ -7,13 +7,12 @@ from .handicap_functions import (
     score_for_passes,
     score_for_round,
 )
-from .handicap_scheme import FloatArray, HandicapScheme
+from .handicap_scheme import HandicapScheme
 from .handicap_scheme_aa import HandicapAA, HandicapAA2
 from .handicap_scheme_agb import HandicapAGB, HandicapAGBold
 from .handicap_tables import HandicapTable
 
 __all__ = [
-    "FloatArray",
     "HandicapAA",
     "HandicapAA2",
     "HandicapAGB",

--- a/archeryutils/handicaps/handicap_functions.py
+++ b/archeryutils/handicaps/handicap_functions.py
@@ -98,7 +98,7 @@ def handicap_scheme(  # noqa: D417 - Missing argument in docstring (**kwargs)
 
 
 def arrow_score(
-    handicap: FloatArray,
+    handicap: npt.ArrayLike,
     target: targets.Target,
     handicap_sys: str | HandicapScheme,
     arw_d: float | None = None,
@@ -108,8 +108,8 @@ def arrow_score(
 
     Parameters
     ----------
-    handicap : FloatArray
-        handicap value to calculate score for
+    handicap : ArrayLike
+        handicap(s) to calculate score for
     target : targets.Target
         A Target class specifying the target to be used
     handicap_sys : str | HandicapScheme
@@ -150,7 +150,7 @@ def arrow_score(
 
 
 def score_for_passes(
-    handicap: FloatArray,
+    handicap: npt.ArrayLike,
     rnd: rounds.Round,
     handicap_sys: str | HandicapScheme,
     arw_d: float | None = None,
@@ -161,8 +161,8 @@ def score_for_passes(
 
     Parameters
     ----------
-    handicap : FloatArray
-        handicap value to calculate score for
+    handicap : ArrayLike
+        handicap value(s) to calculate score for
     rnd : rounds.Round
         A Round class specifying the round being shot
     handicap_sys : str | HandicapScheme
@@ -214,7 +214,7 @@ def score_for_passes(
 
 
 def score_for_round(
-    handicap: FloatArray,
+    handicap: npt.ArrayLike,
     rnd: rounds.Round,
     handicap_sys: str | HandicapScheme,
     arw_d: float | None = None,
@@ -225,8 +225,8 @@ def score_for_round(
 
     Parameters
     ----------
-    handicap : FloatArray
-        handicap value to calculate score for
+    handicap : ArrayLike
+        handicap(s) to calculate score for
     rnd : rounds.Round
         A Round class specifying the round being shot
     handicap_sys : str | HandicapScheme

--- a/archeryutils/handicaps/handicap_functions.py
+++ b/archeryutils/handicaps/handicap_functions.py
@@ -26,7 +26,7 @@ import numpy.typing as npt
 
 from archeryutils import rounds, targets
 
-from .handicap_scheme import FloatArray, HandicapScheme
+from .handicap_scheme import HandicapScheme
 from .handicap_scheme_aa import HandicapAA, HandicapAA2
 from .handicap_scheme_agb import HandicapAGB, HandicapAGBold
 
@@ -102,7 +102,7 @@ def arrow_score(
     target: targets.Target,
     handicap_sys: str | HandicapScheme,
     arw_d: float | None = None,
-) -> FloatArray:
+) -> npt.NDArray[np.float64]:
     """
     Calculate the average arrow score for a given target and handicap rating.
 
@@ -119,7 +119,7 @@ def arrow_score(
 
     Returns
     -------
-    FloatArray
+    NDArray[np.float64]
         average expected arrow score for this handicap and target
 
     Warnings
@@ -238,7 +238,7 @@ def score_for_round(
 
     Returns
     -------
-    round_score : FloatArray
+    round_score : NDArray[np.float64]
         average score of the round for this set of parameters
 
     Examples

--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -34,7 +34,6 @@ References
 import itertools as itr
 import warnings
 from abc import ABC, abstractmethod
-from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -43,12 +42,12 @@ from archeryutils import rounds, targets
 
 
 def _cast_float_array(var_in: npt.ArrayLike) -> npt.NDArray[np.float64]:
-    """Check we can cast to np.float64 array and do so.
+    """Ensure we can cast to a np.float64 array and do so.
 
     Parameters
     ----------
     var_in : ArrayLike
-        input that is an ArrayLik
+        input that is an ArrayLike
 
     Returns
     -------
@@ -61,10 +60,11 @@ def _cast_float_array(var_in: npt.ArrayLike) -> npt.NDArray[np.float64]:
         If an ArrayLike that cannot be cast is passed in.
 
     """
-    if np.can_cast(np.asarray(var_in), np.float64):
-        return np.asarray(var_in).astype(np.float64, casting="safe")
-    err_msg = f"Inappropriate input for handicaps code. Must be numeric value."
-    raise TypeError(err_msg)
+    try:
+        return np.asarray(var_in, dtype=np.float64)
+    except ValueError as exc:
+        err_msg = f"Inappropriate input for handicaps code. Must be numeric value."
+        raise TypeError(err_msg) from None
 
 
 class HandicapScheme(ABC):
@@ -730,5 +730,5 @@ class HandicapScheme(ABC):
 
         """
         val = self.score_for_round(hc_est, round_est, arw_d=arw_d, rounded_score=False)
-        # val is known to be a 0D array, so cast to float for type checker
-        return cast(float, val) - score_est
+        # val is known to be a 0D array, so cast to float for subsequent use
+        return float(val) - score_est

--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -34,7 +34,7 @@ References
 import itertools as itr
 import warnings
 from abc import ABC, abstractmethod
-from typing import TypeVar, cast
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt

--- a/archeryutils/handicaps/handicap_scheme.py
+++ b/archeryutils/handicaps/handicap_scheme.py
@@ -41,8 +41,6 @@ import numpy.typing as npt
 
 from archeryutils import rounds, targets
 
-FloatArray = npt.NDArray[np.float64]
-
 
 class HandicapScheme(ABC):
     r"""
@@ -94,7 +92,7 @@ class HandicapScheme(ABC):
         return f"<HandicapScheme: '{self.name}'>"
 
     @abstractmethod
-    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
@@ -106,12 +104,12 @@ class HandicapScheme(ABC):
 
         Returns
         -------
-        sig_t : FloatArray
+        sig_t : NDArray[np.float64]
             angular deviation [rad]
 
         """
 
-    def sigma_r(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_r(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate radial deviation for a given handicap and distance.
 
         Standard deviation as a proxy for 'group size' based on
@@ -127,7 +125,7 @@ class HandicapScheme(ABC):
 
         Returns
         -------
-        sig_r : FloatArray
+        sig_r : NDArray[np.float64]
             standard deviation of group size [metres]
 
         Examples
@@ -157,7 +155,7 @@ class HandicapScheme(ABC):
         handicap: npt.ArrayLike,
         target: targets.Target,
         arw_d: float | None = None,
-    ) -> FloatArray:
+    ) -> npt.NDArray[np.float64]:
         """Calculate the average arrow score for a given target and handicap rating.
 
         Parameters
@@ -171,7 +169,7 @@ class HandicapScheme(ABC):
 
         Returns
         -------
-        s_bar : FloatArray
+        s_bar : NDArray[np.float64]
             average score of the arrow for this set of parameters
 
         References
@@ -211,8 +209,11 @@ class HandicapScheme(ABC):
         return self._s_bar(spec, arw_rad, sig_r)
 
     def _s_bar(
-        self, target_specs: targets.FaceSpec, arw_rad: float, sig_r: FloatArray
-    ) -> FloatArray:
+        self,
+        target_specs: targets.FaceSpec,
+        arw_rad: float,
+        sig_r: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
         """Calculate expected score directly from target ring sizes.
 
         Parameters
@@ -221,12 +222,12 @@ class HandicapScheme(ABC):
             Mapping of target ring *diameters* in [metres], to points scored
         arw_rad : float
             arrow radius in [metres]
-        sig_r : float
+        sig_r : NDArray[np.float64]
             standard deviation of group size [metres]
 
         Returns
         -------
-        s_bar : FloatArray
+        s_bar : NDArray[np.float64]
             expected average score per arrow
 
         Notes
@@ -254,7 +255,7 @@ class HandicapScheme(ABC):
         rnd: rounds.Round,
         arw_d: float | None = None,
         rounded_score: bool = True,
-    ) -> FloatArray:
+    ) -> npt.NDArray[np.float64]:
         """Calculate the expected score for all passes in a round at a given handicap.
 
         Parameters
@@ -271,7 +272,7 @@ class HandicapScheme(ABC):
 
         Returns
         -------
-        pass_scores : FloatArray
+        pass_scores : NDArray[np.float64]
             average score for each pass in the round
 
         Examples
@@ -314,7 +315,7 @@ class HandicapScheme(ABC):
         rnd: rounds.Round,
         arw_d: float | None = None,
         rounded_score: bool = True,
-    ) -> FloatArray:
+    ) -> npt.NDArray[np.float64]:
         """Calculate the expected score for a round at a given handicap.
 
         Parameters
@@ -330,7 +331,7 @@ class HandicapScheme(ABC):
 
         Returns
         -------
-        round_score : FloatArray
+        round_score : NDArray[np.float64]
             average score of the round for this set of parameters
 
         Examples
@@ -371,7 +372,7 @@ class HandicapScheme(ABC):
         return self._rounded_score(round_score) if rounded_score else round_score
 
     @staticmethod
-    def _rounded_score(score: FloatArray) -> FloatArray:
+    def _rounded_score(score: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
         """
         Round a decimal score to an integer value.
 
@@ -380,12 +381,12 @@ class HandicapScheme(ABC):
 
         Parameters
         ----------
-        score : FloatArray
+        score : NDArray[np.float64]
             raw scores to be rounded according to the handicap system convention
 
         Returns
         -------
-        FloatArray
+        NDArray[np.float64]
             scores after appropriate rounding
         """
         return np.around(score)

--- a/archeryutils/handicaps/handicap_scheme_aa.py
+++ b/archeryutils/handicaps/handicap_scheme_aa.py
@@ -24,7 +24,7 @@ References
 import numpy as np
 import numpy.typing as npt
 
-from .handicap_scheme import HandicapScheme
+from .handicap_scheme import HandicapScheme, _cast_float_array
 
 
 class HandicapAA(HandicapScheme):
@@ -73,15 +73,15 @@ class HandicapAA(HandicapScheme):
     ):
         super().__init__()
 
-        self.name = "AA"
+        self.name: str = "AA"
 
-        self.arw_d_out = 5.0e-3
+        self.arw_d_out: float = 5.0e-3
         self.arw_d_in: float = 9.3e-3
 
         # AA Uses an ascending scale with round. All numbers typically in [-250, 175]
-        self.desc_scale = False
-        self.scale_bounds = [-250, 175]
-        self.max_score_rounding_lim = 0.5
+        self.desc_scale: bool = False
+        self.scale_bounds: npt.NDArray[np.float64] = np.array([-250, 175])
+        self.max_score_rounding_lim: float = 0.5
 
         self.params = {
             "ang_0": ang_0,  # Baseline angle used for group size 1.0 [millirad].
@@ -135,7 +135,7 @@ class HandicapAA(HandicapScheme):
         array([0.0127633 , 0.00433436, 0.00112364])
 
         """
-        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+        handicap = _cast_float_array(handicap)  # Cast for calculation
 
         # Factor of sqrt(2) to deal with factor of 2 in differing definitions of sigma
         # between AGB and AA
@@ -205,15 +205,15 @@ class HandicapAA2(HandicapScheme):
     ):
         super().__init__()
 
-        self.name = "AA2"
+        self.name: str = "AA2"
 
-        self.arw_d_out = 5.0e-3
-        self.arw_d_in = 9.3e-3
+        self.arw_d_out: float = 5.0e-3
+        self.arw_d_in: float = 9.3e-3
 
         # AA Uses an ascending scale with round. All numbers typically in [-250, 175]
-        self.desc_scale = False
-        self.scale_bounds = [-250, 175]
-        self.max_score_rounding_lim = 0.5
+        self.desc_scale: bool = False
+        self.scale_bounds: npt.NDArray[np.float64] = np.array([-250, 175])
+        self.max_score_rounding_lim: float = 0.5
 
         self.params = {
             "ang_0": ang_0,
@@ -269,7 +269,7 @@ class HandicapAA2(HandicapScheme):
         array([0.01280085, 0.00434711, 0.00112695])
 
         """
-        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+        handicap = _cast_float_array(handicap)  # Cast for calculation
 
         # Factor of sqrt(2) to deal with factor of 2 in differing definitions of sigma
         # between AGB and AA

--- a/archeryutils/handicaps/handicap_scheme_aa.py
+++ b/archeryutils/handicaps/handicap_scheme_aa.py
@@ -22,6 +22,7 @@ References
 """
 
 import numpy as np
+import numpy.typing as npt
 
 from .handicap_scheme import FloatArray, HandicapScheme
 
@@ -89,13 +90,13 @@ class HandicapAA(HandicapScheme):
             "kd": kd,  # Distance scaling factor [1/metres].
         }
 
-    def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
         ----------
-        handicap : FloatArray
-            handicap to calculate sigma_t at
+        handicap : ArrayLike
+            handicap(s) to calculate sigma_t at
         dist : float
             distance to target [metres]
 
@@ -134,6 +135,8 @@ class HandicapAA(HandicapScheme):
         array([0.0127633 , 0.00433436, 0.00112364])
 
         """
+        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+
         # Factor of sqrt(2) to deal with factor of 2 in differing definitions of sigma
         # between AGB and AA
         # Required so code elsewhere is unchanged
@@ -221,13 +224,13 @@ class HandicapAA2(HandicapScheme):
             "d0": d0,  # Normalisation distance [metres].
         }
 
-    def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
         ----------
-        handicap : FloatArray
-            handicap to calculate sigma_t at
+        handicap : ArrayLike
+            handicap(s) to calculate sigma_t at
         dist : float
             distance to target [metres]
 
@@ -266,6 +269,8 @@ class HandicapAA2(HandicapScheme):
         array([0.01280085, 0.00434711, 0.00112695])
 
         """
+        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+
         # Factor of sqrt(2) to deal with factor of 2 in differing definitions of sigma
         # between AGB and AA
         # Required so code elsewhere is unchanged

--- a/archeryutils/handicaps/handicap_scheme_aa.py
+++ b/archeryutils/handicaps/handicap_scheme_aa.py
@@ -24,7 +24,7 @@ References
 import numpy as np
 import numpy.typing as npt
 
-from .handicap_scheme import FloatArray, HandicapScheme
+from .handicap_scheme import HandicapScheme
 
 
 class HandicapAA(HandicapScheme):
@@ -90,7 +90,7 @@ class HandicapAA(HandicapScheme):
             "kd": kd,  # Distance scaling factor [1/metres].
         }
 
-    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
@@ -102,7 +102,7 @@ class HandicapAA(HandicapScheme):
 
         Returns
         -------
-        sig_t : FloatArray
+        sig_t : NDArray[np.float64]
             angular deviation [rad]
 
         Notes
@@ -224,7 +224,7 @@ class HandicapAA2(HandicapScheme):
             "d0": d0,  # Normalisation distance [metres].
         }
 
-    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
@@ -236,7 +236,7 @@ class HandicapAA2(HandicapScheme):
 
         Returns
         -------
-        sig_t : FloatArray
+        sig_t : NDArray[np.float64]
             angular deviation [rad]
 
         Notes

--- a/archeryutils/handicaps/handicap_scheme_agb.py
+++ b/archeryutils/handicaps/handicap_scheme_agb.py
@@ -23,6 +23,7 @@ References
 """
 
 import numpy as np
+import numpy.typing as npt
 
 from .handicap_scheme import FloatArray, HandicapScheme
 
@@ -92,13 +93,13 @@ class HandicapAGB(HandicapScheme):
             "kd": kd,
         }
 
-    def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
         ----------
-        handicap : FloatArray
-            handicap to calculate sigma_t at
+        handicap : ArrayLike
+            handicap(s) to calculate sigma_t at
         dist : float
             distance to target [metres]
 
@@ -124,6 +125,7 @@ class HandicapAGB(HandicapScheme):
         array([0.00094983, 0.00376062, 0.02100276])
 
         """
+        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
         return (
             self.params["ang_0"]
             * ((1.0 + self.params["step"] / 100.0) ** (handicap + self.params["datum"]))
@@ -211,13 +213,13 @@ class HandicapAGBold(HandicapScheme):
             "p1": p1,  # Exponent of distance scaling.
         }
 
-    def sigma_t(self, handicap: FloatArray, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
         ----------
-        handicap : FloatArray
-            handicap to calculate sigma_t at
+        handicap : ArrayLike
+            handicap(s) to calculate sigma_t at
         dist : float
             distance to target [metres]
 
@@ -253,10 +255,13 @@ class HandicapAGBold(HandicapScheme):
         array([0.00112649, 0.00478762, 0.05520862])
 
         """
+        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+
         k_factor = self.params["k1"] * self.params["k2"] ** (
             handicap + self.params["k3"]
         )
         f_factor = 1.0 + k_factor * dist ** self.params["p1"]
+
         return (
             self.params["ang_0"]
             * ((1.0 + self.params["step"] / 100.0) ** (handicap + self.params["datum"]))

--- a/archeryutils/handicaps/handicap_scheme_agb.py
+++ b/archeryutils/handicaps/handicap_scheme_agb.py
@@ -25,7 +25,7 @@ References
 import numpy as np
 import numpy.typing as npt
 
-from .handicap_scheme import FloatArray, HandicapScheme
+from .handicap_scheme import HandicapScheme
 
 
 class HandicapAGB(HandicapScheme):
@@ -93,7 +93,7 @@ class HandicapAGB(HandicapScheme):
             "kd": kd,
         }
 
-    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
@@ -105,7 +105,7 @@ class HandicapAGB(HandicapScheme):
 
         Returns
         -------
-        sig_t : FloatArray
+        sig_t : NDArray[np.float64]
             angular deviation [rad]
 
         Examples
@@ -213,7 +213,7 @@ class HandicapAGBold(HandicapScheme):
             "p1": p1,  # Exponent of distance scaling.
         }
 
-    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> FloatArray:
+    def sigma_t(self, handicap: npt.ArrayLike, dist: float) -> npt.NDArray[np.float64]:
         """Calculate angular deviation for given handicap and distance.
 
         Parameters
@@ -225,7 +225,7 @@ class HandicapAGBold(HandicapScheme):
 
         Returns
         -------
-        sig_t : FloatArray
+        sig_t : NDArray[np.float64]
             angular deviation [rad]
 
         Notes

--- a/archeryutils/handicaps/handicap_scheme_agb.py
+++ b/archeryutils/handicaps/handicap_scheme_agb.py
@@ -25,7 +25,7 @@ References
 import numpy as np
 import numpy.typing as npt
 
-from .handicap_scheme import HandicapScheme
+from .handicap_scheme import HandicapScheme, _cast_float_array
 
 
 class HandicapAGB(HandicapScheme):
@@ -76,14 +76,14 @@ class HandicapAGB(HandicapScheme):
     ):
         super().__init__()
 
-        self.name = "AGB"
+        self.name: str = "AGB"
 
         self.arw_d_out: float = 5.5e-3
         self.arw_d_in: float = 9.3e-3
 
         # AGB Uses a descending scale with ceil. All numbers typically in [-75, 300]
         self.desc_scale: bool = True
-        self.scale_bounds: list[float] = [-75, 300]
+        self.scale_bounds: npt.NDArray[np.float64] = np.array([-75, 300])
         self.max_score_rounding_lim: float = 1.0
 
         self.params = {
@@ -125,7 +125,8 @@ class HandicapAGB(HandicapScheme):
         array([0.00094983, 0.00376062, 0.02100276])
 
         """
-        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+        handicap = _cast_float_array(handicap)  # Cast for calculation
+
         return (
             self.params["ang_0"]
             * ((1.0 + self.params["step"] / 100.0) ** (handicap + self.params["datum"]))
@@ -193,15 +194,15 @@ class HandicapAGBold(HandicapScheme):
     ):
         super().__init__()
 
-        self.name = "AGBold"
+        self.name: str = "AGBold"
 
-        self.arw_d_out = 7.14e-3
-        self.arw_d_in = 7.14e-3
+        self.arw_d_out: float = 7.14e-3
+        self.arw_d_in: float = 7.14e-3
 
         # AGBold Uses a descending scale with round. All numbers typically in [-75, 300]
-        self.desc_scale = True
-        self.scale_bounds = [-75, 300]
-        self.max_score_rounding_lim = 0.5
+        self.desc_scale: bool = True
+        self.scale_bounds: npt.NDArray[np.float64] = np.array([-75, 300])
+        self.max_score_rounding_lim: float = 0.5
 
         self.params = {
             "datum": datum,  # Offset required to set handicap 0 at desired score.
@@ -255,7 +256,7 @@ class HandicapAGBold(HandicapScheme):
         array([0.00112649, 0.00478762, 0.05520862])
 
         """
-        handicap = np.asarray(handicap)  # Ensure numpy array for calculations
+        handicap = _cast_float_array(handicap)  # Cast for calculation
 
         k_factor = self.params["k1"] * self.params["k2"] ** (
             handicap + self.params["k3"]

--- a/archeryutils/handicaps/handicap_tables.py
+++ b/archeryutils/handicaps/handicap_tables.py
@@ -15,7 +15,7 @@ import numpy.typing as npt
 import archeryutils.handicaps.handicap_functions as hc
 from archeryutils import rounds
 
-from .handicap_scheme import FloatArray, HandicapScheme
+from .handicap_scheme import HandicapScheme
 
 _FILL = -9999
 
@@ -28,7 +28,7 @@ class HandicapTable:
     ----------
     handicap_sys : str | HandicapScheme
         identifier for the handicap system to use
-    hcs : FloatArray | NDArray[np.int\\_]
+    hcs : ArrayLike
         handicap values to calculate scores for
     round_list : list[rounds.Round]
         list of Round classes to show in the handicap table
@@ -55,9 +55,9 @@ class HandicapTable:
         display numbers in table as integers rather than decimals to improve appearance
     clean_gaps : bool
         clean out gaps of repeated scores (using only first occurrence)
-    hcs : NDArray[np.float\\_]
+    hcs : NDArray[np.float64]
         handicap values to calculate scores for
-    table: NDArray[np.float\\_ | np.int\\_]
+    table: NDArray[np.float64 | np.int\\_]
         the generated handicap table containing appropriate score values
 
     """
@@ -79,7 +79,7 @@ class HandicapTable:
         self.clean_gaps = clean_gaps
 
         # Sanitise inputs
-        self.hcs = self._check_print_table_inputs(hcs)
+        self.hcs: npt.NDArray[np.float64] = self._check_print_table_inputs(hcs)
 
         # Set up empty handicap table and populate
         self.table: npt.NDArray[np.float64 | np.int_] = np.empty(
@@ -256,7 +256,7 @@ class HandicapTable:
 
         Returns
         -------
-        hcs : NDArray
+        hcs : NDArray[np.float64]
             handicaps prepared for use in table printing routines
 
         Raises
@@ -356,7 +356,7 @@ class HandicapTable:
 
         Parameters
         ----------
-        row : NDArray
+        row : NDArray[np.float64 | np.int_]
             numpy array of data for one table row
         hc_dp : int, default=0
             handicap decimal places

--- a/archeryutils/handicaps/handicap_tables.py
+++ b/archeryutils/handicaps/handicap_tables.py
@@ -267,10 +267,8 @@ class HandicapTable:
             If no rounds are provided for the handicap table
 
         """
-        hcs_in = np.asarray(hcs_in)  # Explicitly cast to array for calculations
-
         try:
-            hcs = hcs_in.astype(np.float64)
+            hcs = np.asarray(hcs_in, dtype=np.float64)
         except ValueError as exc:
             msg = "Cannot convert supplied handicaps to float for HandicapTable."
             raise TypeError(msg) from exc

--- a/archeryutils/handicaps/tests/test_handicap_tables.py
+++ b/archeryutils/handicaps/tests/test_handicap_tables.py
@@ -208,6 +208,6 @@ class TestHandicapTable:
         """Check that inappropriate handicaps triggers error."""
         with pytest.raises(
             TypeError,
-            match=("Expected float or ndarray for hcs."),
+            match=("Cannot convert supplied handicaps to float for HandicapTable."),
         ):
             hc.HandicapTable("AGB", "a", [york, hereford])  # type: ignore

--- a/archeryutils/handicaps/tests/test_handicaps.py
+++ b/archeryutils/handicaps/tests/test_handicaps.py
@@ -192,6 +192,28 @@ class TestSigmaT:
 
         assert theta == pytest.approx(theta_expected)
 
+    @pytest.mark.parametrize(
+        "hc_system",
+        [
+            "AGB",
+            "AGBold",
+            "AA",
+            "AA2",
+        ],
+    )
+    def test_bad_type(self, hc_system: str) -> None:
+        """Check TypeError is raised when sigma_t cannot cast to NDArray[np.float64]."""
+        handicap_array = "A string is not a numeric handicsap"
+        hc_sys = hc.handicap_scheme(hc_system)
+        with pytest.raises(
+            TypeError,
+            match=("Inappropriate input for handicaps code. Must be numeric value."),
+        ):
+            theta_array = hc_sys.sigma_t(
+                handicap=handicap_array,
+                dist=100.0,
+            )
+
     def test_array(self) -> None:
         """Check that sigma_t(handicap=ndarray) returns expected value for a case."""
         handicap_array = np.array([25.46, -12.0, 200.0])
@@ -203,6 +225,28 @@ class TestSigmaT:
         )
 
         np.testing.assert_allclose(theta_array, theta_expected_array)
+
+    @pytest.mark.parametrize(
+        "hc_system",
+        [
+            "AGB",
+            "AGBold",
+            "AA",
+            "AA2",
+        ],
+    )
+    def test_bad_array_type(self, hc_system: str) -> None:
+        """Check TypeError is raised when sigma_t cannot cast to NDArray[np.float64]."""
+        handicap_array = np.array(["a", "b", "c"])
+        hc_sys = hc.handicap_scheme(hc_system)
+        with pytest.raises(
+            TypeError,
+            match=("Inappropriate input for handicaps code. Must be numeric value."),
+        ):
+            theta_array = hc_sys.sigma_t(
+                handicap=handicap_array,
+                dist=100.0,
+            )
 
 
 class TestSigmaR:

--- a/docs/develop/whats-new.rst
+++ b/docs/develop/whats-new.rst
@@ -3,6 +3,7 @@ What's New
 
 Latest
 ------
+* Better use of numpy typing in `#133 <https://github.com/jatkinson1000/archeryutils/pull/133>`_
 * Allow inputs to classification functions to be an archeryutils `Round`
   as well as a string in `#119 <https://github.com/jatkinson1000/archeryutils/pull/119>`_
 * Add new AGB 900 rounds in `#116 <https://github.com/jatkinson1000/archeryutils/pull/116>`_


### PR DESCRIPTION
Use numpy typing closer to intended use as suggested by @LiamPattinson in #130

Take inputs to functions as `ArrayLike`, casting using `np.asarray()` where appropriate.
Return items as `NDArray[float64]` with single values being duck-typed in the majority of cases.
Removes the `FloatArray` type to just use `NDArray[float64]` explicitly.

Resolves a number of issues seen in latest mypy in a more sensible manner than #130 
Also allows us to simplify some of the "type-checker" appeasement throughout the code e.g. castings and overloads.