### PR TITLE
Add a workflow to automate publication of semver tagged releases to PyPI

### DIFF
--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,0 +1,62 @@
+# Workflow to publish versioned commits to PyPI
+name: PyPI-release
+
+on:
+  # run on every push to main
+  push:
+    branches:
+      - main
+    tags:
+      # Semver glob
+      - 'v[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'
+
+jobs:
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install build tool
+        run: python3 -m pip install --upgrade build
+
+      - name: Build binary wheel and source tarball
+        run: python3 -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/archeryutils
+
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
* Activates for any tag matching semver regex.
* Required setting permissions for trusted publication from GitHub on PyPI.